### PR TITLE
fix: emit AdminChanged event on admin updates

### DIFF
--- a/contracts/price-oracle/src/auth.rs
+++ b/contracts/price-oracle/src/auth.rs
@@ -15,7 +15,19 @@ pub enum DataKey {
 // ─────────────────────────────────────────────────────────────────────────────
 
 pub fn _set_admin(env: &Env, admin: &Address) {
+    let previous_admin = if _has_admin(env) {
+        Some(_get_admin(env))
+    } else {
+        None
+    };
+
     env.storage().instance().set(&DataKey::Admin, admin);
+
+    crate::AdminChanged {
+        previous_admin,
+        new_admin: admin.clone(),
+    }
+    .publish(env);
 }
 
 pub fn _get_admin(env: &Env) -> Address {
@@ -254,5 +266,34 @@ mod auth_tests {
             assert!(_is_admin(&env, &admin));
             assert!(!_is_provider(&env, &admin));
         });
+    }
+
+    // ── AdminChanged event tests ─────────────────────────────────────────────
+
+    #[test]
+    fn test_set_admin_emits_event_on_first_set() {
+        let env = Env::default();
+        let contract_id = env.register(TestContract, ());
+        let admin = Address::generate(&env);
+
+        env.as_contract(&contract_id, || {
+            _set_admin(&env, &admin);
+        });
+
+        let events = env.events().all();
+        assert!(!events.is_empty());
+    }
+
+    #[test]
+    fn test_set_admin_emits_event_on_admin_change() {
+        let (env, contract_id, old_admin) = setup();
+        let new_admin = Address::generate(&env);
+
+        env.as_contract(&contract_id, || {
+            _set_admin(&env, &new_admin);
+        });
+
+        let events = env.events().all();
+        assert!(events.len() >= 2);
     }
 }

--- a/contracts/price-oracle/src/lib.rs
+++ b/contracts/price-oracle/src/lib.rs
@@ -29,6 +29,14 @@ pub struct PriceUpdated {
     pub timestamp: u64,
 }
 
+/// Event emitted when the admin address is changed
+#[contractevent]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct AdminChanged {
+    pub previous_admin: Option<Address>,
+    pub new_admin: Address,
+}
+
 #[contract]
 pub struct PriceOracle;
 


### PR DESCRIPTION
## Summary

- Adds `AdminChanged` event to the price oracle contract
- Emits the event whenever the admin address is set or changed
- Provides full transparency for DAO/community governance tracking

## Root Cause

The `_set_admin` function in `auth.rs` updated the admin address without emitting any event, making admin transitions opaque.

## Fix Implemented

1. Defined `AdminChanged` event struct in `lib.rs` with:
   - `previous_admin: Option<Address>` (None on first set, Some on subsequent changes)
   - `new_admin: Address`

2. Updated `_set_admin` in `auth.rs` to:
   - Capture previous admin before storage update
   - Emit `AdminChanged` event after setting new admin

## Testing Performed

- Added unit tests for event emission on first admin set
- Added unit tests for event emission on admin change

## Closes #16