### PR TITLE
Fix PriceUpdate event implementation in price-oracle contract

### DIFF
--- a/contracts/price-oracle/src/lib.rs
+++ b/contracts/price-oracle/src/lib.rs
@@ -6,6 +6,8 @@ use soroban_sdk::{
 
 use crate::types::PriceData;
 
+const PRICE_DATA_KEY: Symbol = symbol_short!("prices");
+
 /// Error types for the price oracle contract
 #[contracterror]
 #[derive(Copy, Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
@@ -167,6 +169,8 @@ impl PriceOracle {
             timestamp,
         }
         .publish(&env);
+
+        Ok(())
     }
 }
 

--- a/contracts/price-oracle/src/test.rs
+++ b/contracts/price-oracle/src/test.rs
@@ -230,6 +230,31 @@ fn test_update_price_multiple_updates() {
 }
 
 #[test]
+fn test_update_price_emits_event() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let contract_id = env.register(PriceOracle, ());
+    let client = PriceOracleClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    let provider = Address::generate(&env);
+    let asset = symbol_short!("NGN");
+    let price: i128 = 1_500_000;
+
+    env.as_contract(&contract_id, || {
+        crate::auth::_set_admin(&env, &admin);
+        crate::auth::_add_provider(&env, &provider);
+    });
+
+    env.ledger().set_timestamp(1_700_000_000);
+    client.update_price(&provider, &asset, &price);
+
+    let events = env.events().all();
+    assert!(!events.is_empty());
+}
+
+#[test]
 fn test_calculate_percentage_change_bps_for_increase() {
     assert_eq!(
         calculate_percentage_change_bps(1_000_000, 1_200_000),


### PR DESCRIPTION
## Summary

- Adds missing `PRICE_DATA_KEY` storage constant required for price data persistence
- Fixes `update_price` function to properly return `Ok(())` after publishing the `PriceUpdated` event
- Adds `test_update_price_emits_event` test to verify event emission behavior

## Root Cause

The `PriceUpdated` event struct was defined with the `#[contractevent]` macro and `.publish(&env)` was being called, but:
1. The `PRICE_DATA_KEY` constant was used but never defined
2. The `update_price` function had return type `Result<(), Error>` but did not return `Ok(())` after publishing the event
3. No test existed to verify event emission

## Fix Implemented

1. Added `const PRICE_DATA_KEY: Symbol = symbol_short!("prices");` constant
2. Added `Ok(())` return after the event publish in `update_price`
3. Added `test_update_price_emits_event` test that verifies events are emitted when `update_price` is called

## Testing Performed

- Added unit test `test_update_price_emits_event` following existing test patterns
- Test verifies event emission by checking `env.events().all()` is non-empty after `update_price`

# Closes #15