### PR TITLE
feat: implement fixed-point scaling for diverse assets (Closes #26)

### DIFF
--- a/contracts/price-oracle/src/lib.rs
+++ b/contracts/price-oracle/src/lib.rs
@@ -172,6 +172,7 @@ impl PriceOracle {
 
 mod asset_symbol;
 mod auth;
+pub mod math;
 mod median;
 mod test;
 mod types;

--- a/contracts/price-oracle/src/math.rs
+++ b/contracts/price-oracle/src/math.rs
@@ -1,0 +1,33 @@
+pub fn normalize_to_seven(value: i128, input_decimals: u32) -> i128 {
+    if input_decimals < 7 {
+        let diff = 7 - input_decimals;
+        let multiplier = 10_i128.checked_pow(diff).expect("Overflow on multiplier pow");
+        value.checked_mul(multiplier).expect("Overflow on multiplication")
+    } else if input_decimals > 7 {
+        let diff = input_decimals - 7;
+        let divisor = 10_i128.checked_pow(diff).expect("Overflow on divisor pow");
+        value.checked_div(divisor).expect("Overflow on division")
+    } else {
+        value
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_normalize_to_seven_scale_up() {
+        assert_eq!(normalize_to_seven(150, 2), 15_000_000);
+    }
+
+    #[test]
+    fn test_normalize_to_seven_scale_down() {
+        assert_eq!(normalize_to_seven(100_000_000, 9), 1_000_000);
+    }
+
+    #[test]
+    fn test_normalize_to_seven_no_scale() {
+        assert_eq!(normalize_to_seven(1234567, 7), 1234567);
+    }
+}


### PR DESCRIPTION
# Closes #26

---

I have implemented the normalize_to_seven utility in math.rs to handle diverse asset scaling (like NGN vs XLM).