### PR TITLE
# PR: Ledger Time Helper (#39)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,6 @@ target
 # Local settings
 .soroban
 .stellar
+
+
+pr_done.md

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -836,6 +836,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "ledger-time-helper"
+version = "0.0.0"
+dependencies = [
+ "soroban-sdk",
+]
+
+[[package]]
 name = "libc"
 version = "0.2.183"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/contracts/ledger-time-helper/Cargo.toml
+++ b/contracts/ledger-time-helper/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "ledger-time-helper"
+version = "0.0.0"
+edition = "2021"
+publish = false
+
+[lib]
+doctest = false
+
+[dependencies]
+soroban-sdk = { workspace = true }
+
+[dev-dependencies]
+soroban-sdk = { workspace = true, features = ["testutils"] }

--- a/contracts/ledger-time-helper/src/lib.rs
+++ b/contracts/ledger-time-helper/src/lib.rs
@@ -1,0 +1,24 @@
+//! Helpers for reading Soroban ledger (blockchain) time.
+
+use soroban_sdk::Env;
+
+/// Returns the current ledger close time as a Unix timestamp in seconds.
+///
+/// This is the "blockchain time" from the ledger header—the time at which the
+/// ledger was closed—not wall-clock time on the host.
+pub fn current_ledger_timestamp(env: &Env) -> u64 {
+    env.ledger().timestamp()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::current_ledger_timestamp;
+    use soroban_sdk::{testutils::Ledger, Env};
+
+    #[test]
+    fn returns_mock_ledger_timestamp() {
+        let env = Env::default();
+        env.ledger().set_timestamp(1_700_000_123);
+        assert_eq!(current_ledger_timestamp(&env), 1_700_000_123);
+    }
+}


### PR DESCRIPTION
## Summary

Adds a small workspace library crate that exposes **blockchain time** for stamping data: `current_ledger_timestamp(&env)` returns the Soroban ledger close time as a **`u64`** (Unix seconds), implemented as `env.ledger().timestamp()`.

## What changed

- **New crate:** `contracts/ledger-time-helper`
  - Public API: `current_ledger_timestamp(env: &Env) -> u64`
  - Docs clarify this is ledger header close time, not host wall-clock time
  - Unit test uses the mock ledger (`set_timestamp`) to assert the helper returns the expected value
- **Workspace:** Included automatically via `contracts/*`; no change to the root `Cargo.toml` members list
- **`price-oracle`** was not refactored to use the helper (optional follow-up)

## How to verify

```bash
cargo test -p ledger-time-helper
```

## Screenshots

<img width="390" height="345" alt="Screenshot From 2026-03-27 11-48-12" src="https://github.com/user-attachments/assets/2d967d2e-d070-4599-b0a2-c97d91c30c5d" />


Closes #39 