### PR TITLE
feat: create the PriceEntry envelope

### DIFF
--- a/contracts/price-oracle/src/types.rs
+++ b/contracts/price-oracle/src/types.rs
@@ -23,3 +23,11 @@ pub struct PriceData {
     /// Confidence score (0-100, higher is more confident)
     pub confidence_score: u32,
 }
+
+/// A simplified price entry for external consumers.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct PriceEntry {
+    pub price: i128,
+    pub timestamp: u64,
+}


### PR DESCRIPTION
# closes #37 

feat: create the PriceEntry envelope

PR Description:
This PR implements the 

PriceEntry
 struct in the price-oracle contract. This struct is designed to provide a simplified data structure for external consumers to retrieve price values alongside their recorded timestamps.

What was done:

Added 

PriceEntry
 struct to 

contracts/price-oracle/src/types.rs
.
Defined fields: price (i128) and timestamp (u64).
Added #[contracttype] and common traits (Clone, Debug, Eq, PartialEq).
Why it was done: To provide a clear, standard "envelope" for price data that is easy for other contracts or services to consume.

How it was verified:

Manual inspection of the code against the provided starter code.
Verification that the struct uses proper Soroban SDK types and macros.
(Note: cargo build was attempted but the tool was not found in the environment's PATH).
