### PR TITLE
Implemented Per-Asset Expiration Logic

### DIFF
--- a/contracts/price-oracle/src/lib.rs
+++ b/contracts/price-oracle/src/lib.rs
@@ -69,6 +69,22 @@ fn is_valid(price: i128) -> bool {
     price > 0
 }
 
+/// Check if a price entry is stale based on its TTL.
+///
+/// A price is considered stale if the current ledger timestamp has passed
+/// the expiration time (stored_timestamp + ttl).
+///
+/// # Arguments
+/// * `current_time` - The current ledger timestamp
+/// * `stored_timestamp` - The timestamp when the price was stored
+/// * `ttl` - The time-to-live in seconds
+///
+/// # Returns
+/// `true` if the price is stale (expired), `false` otherwise
+fn is_stale(current_time: u64, stored_timestamp: u64, ttl: u64) -> bool {
+    current_time >= stored_timestamp.saturating_add(ttl)
+}
+
 #[contractimpl]
 impl PriceOracle {
     /// Initialize the contract with admin and base currency pairs.
@@ -93,10 +109,9 @@ impl PriceOracle {
 
         match prices.get(asset) {
             Some(price_data) => {
-                // Staleness check: 1 hour (3600 seconds)
+                // Check if price is stale using per-asset TTL
                 let now = env.ledger().timestamp();
-                let max_age = 3600u64;
-                if now > price_data.timestamp && now - price_data.timestamp > max_age {
+                if is_stale(now, price_data.timestamp, price_data.ttl) {
                     return Err(Error::AssetNotFound); // Could define a new error for StalePrice
                 }
                 Ok(price_data)
@@ -134,7 +149,14 @@ impl PriceOracle {
     }
 
     /// Set the price data for a specific asset.
-    pub fn set_price(env: Env, asset: Symbol, val: i128, decimals: u32) {
+    ///
+    /// # Arguments
+    /// * `env` - The contract environment
+    /// * `asset` - The asset symbol to set
+    /// * `val` - The price value
+    /// * `decimals` - Number of decimals for the price
+    /// * `ttl` - Time-to-live in seconds for this price (per-asset expiration)
+    pub fn set_price(env: Env, asset: Symbol, val: i128, decimals: u32, ttl: u64) {
         let storage = env.storage().persistent();
         let mut prices: soroban_sdk::Map<Symbol, PriceData> = storage
             .get(&DataKey::PriceData)
@@ -147,6 +169,7 @@ impl PriceOracle {
             provider: env.current_contract_address(),
             decimals,
             confidence_score: 100,
+            ttl,
         };
 
         prices.set(asset, price_data);
@@ -160,6 +183,9 @@ impl PriceOracle {
     /// * `source` - The address of the authorized backend relayer
     /// * `asset` - The asset symbol to update
     /// * `price` - The new price (as i128)
+    /// * `decimals` - Number of decimals for the price
+    /// * `confidence_score` - Confidence score for this price update
+    /// * `ttl` - Time-to-live in seconds for this price (per-asset expiration)
     ///
     /// # Errors
     /// * `Error::InvalidAssetSymbol` - If `asset` is not NGN, KES, or GHS
@@ -173,6 +199,7 @@ impl PriceOracle {
         price: i128,
         decimals: u32,
         confidence_score: u32,
+        ttl: u64,
     ) -> Result<(), Error> {
         source.require_auth();
 
@@ -205,6 +232,7 @@ impl PriceOracle {
             provider: source.clone(),
             decimals,
             confidence_score,
+            ttl,
         };
 
         prices.set(asset.clone(), price_data);

--- a/contracts/price-oracle/src/test.rs
+++ b/contracts/price-oracle/src/test.rs
@@ -100,7 +100,7 @@ fn test_get_price_existing_asset() {
     env.ledger().set_sequence_number(1);
 
     let asset = symbol_short!("XLM");
-    client.set_price(&asset, &1_000_000_i128, &6u32);
+    client.set_price(&asset, &1_000_000_i128, &6u32, &3600u64);
 
     let retrieved_price = client.get_price(&asset);
     assert_eq!(retrieved_price.price, 1_000_000_i128);
@@ -130,7 +130,7 @@ fn test_get_price_after_update() {
     env.ledger().set_timestamp(1_234_567_890);
     env.ledger().set_sequence_number(1);
     client
-        .try_set_price(&asset, &1_000_000_i128, &6u32)
+        .try_set_price(&asset, &1_000_000_i128, &6u32, &3600u64)
         .unwrap()
         .unwrap();
 
@@ -141,7 +141,7 @@ fn test_get_price_after_update() {
     env.ledger().set_timestamp(1_234_567_900);
     env.ledger().set_sequence_number(2);
     client
-        .try_set_price(&asset, &1_200_000_i128, &6u32)
+        .try_set_price(&asset, &1_200_000_i128, &6u32, &3600u64)
         .unwrap()
         .unwrap();
 
@@ -162,8 +162,8 @@ fn test_get_all_assets_returns_tracked_symbols() {
     let ngn = symbol_short!("NGN");
     let kes = symbol_short!("KES");
 
-    client.set_price(&ngn, &1_500_i128, &2u32);
-    client.set_price(&kes, &800_i128, &2u32);
+    client.set_price(&ngn, &1_500_i128, &2u32, &3600u64);
+    client.set_price(&kes, &800_i128, &2u32, &14400u64);
 
     let assets = client.get_all_assets();
     assert_eq!(assets.len(), 2);
@@ -180,7 +180,7 @@ fn test_set_price_uses_current_ledger_timestamp() {
 
     env.ledger().set_timestamp(1_700_000_123);
     env.ledger().set_sequence_number(77);
-    client.set_price(&asset, &950_i128, &2u32);
+    client.set_price(&asset, &950_i128, &2u32, &3600u64);
 
     let stored = client.get_price(&asset);
     assert_eq!(stored.price, 950_i128);
@@ -206,7 +206,7 @@ fn test_update_price_provider_can_store_new_price() {
 
     env.ledger().set_timestamp(1_700_000_500);
     env.ledger().set_sequence_number(2);
-    client.update_price(&provider, &asset, &1_500_000_i128, &6u32, &100u32);
+    client.update_price(&provider, &asset, &1_500_000_i128, &6u32, &100u32, &3600u64);
 
     let stored = client.get_price(&asset);
     assert_eq!(stored.price, 1_500_000_i128);
@@ -231,8 +231,8 @@ fn test_update_price_multiple_updates() {
         crate::auth::_add_provider(&env, &provider);
     });
 
-    client.update_price(&provider, &asset, &1_000_000_i128, &6u32, &100u32);
-    client.update_price(&provider, &asset, &1_200_000_i128, &6u32, &100u32);
+    client.update_price(&provider, &asset, &1_000_000_i128, &6u32, &100u32, &3600u64);
+    client.update_price(&provider, &asset, &1_200_000_i128, &6u32, &100u32, &3600u64);
 
     let stored = client.get_price(&asset);
     assert_eq!(stored.price, 1_200_000_i128);
@@ -259,6 +259,7 @@ fn test_update_price_unauthorized_rejection() {
         &50_000_000_000_i128,
         &8u32,
         &100u32,
+        &3600u64,
     );
     assert!(result.is_err());
 }
@@ -280,7 +281,7 @@ fn test_update_price_rejects_unapproved_symbol() {
 
     let asset = symbol_short!("ETH");
     let price: i128 = 1_000_000;
-
+, &3600u64
     match client.try_update_price(&provider, &asset, &price, &6u32, &100u32) {
         Err(Ok(e)) => assert_eq!(e, Error::InvalidAssetSymbol),
         other => panic!("expected InvalidAssetSymbol, got {:?}", other),
@@ -305,9 +306,9 @@ fn test_update_price_emits_event() {
         crate::auth::_set_admin(&env, &admin);
         crate::auth::_add_provider(&env, &provider);
     });
-
-    client.set_price(&asset, &old_price);
+, &2u32, &3600u64);
     env.ledger().set_timestamp(1_700_000_000);
+    client.update_price(&provider, &asset, &price, &6u32, &100u32, &3600u64
     client.update_price(&provider, &asset, &price);
 
     // let events = env.events().all();
@@ -347,3 +348,22 @@ fn test_calculate_percentage_change_returns_none_for_zero_baseline() {
     assert_eq!(calculate_percentage_change_bps(0, 1_000_000), None);
     assert_eq!(calculate_percentage_difference_bps(0, 1_000_000), None);
 }
+
+#[test]
+fn test_is_stale_with_mocked_ledger_time() {
+    // Test case: ledger_time=2000, stored_timestamp=1000, ttl=500
+    // Expected: 2000 >= (1000 + 500) = 2000 >= 1500 = true (stale)
+    let current_time = 2000u64;
+    let stored_timestamp = 1000u64;
+    let ttl = 500u64;
+    
+    assert!(is_stale(current_time, stored_timestamp, ttl), "Price should be stale");
+    
+    // Additional test: not stale case
+    // current_time < stored_timestamp + ttl should return false
+    assert!(!is_stale(1400u64, 1000u64, 500u64), "Price should not be stale when within TTL");
+    
+    // Edge case: exactly at expiration boundary
+    assert!(is_stale(1500u64, 1000u64, 500u64), "Price should be stale at expiration boundary");
+}
+

--- a/contracts/price-oracle/src/types.rs
+++ b/contracts/price-oracle/src/types.rs
@@ -22,6 +22,8 @@ pub struct PriceData {
     pub decimals: u32,
     /// Confidence score (0-100, higher is more confident)
     pub confidence_score: u32,
+    /// Time-to-live in seconds for this price (per-asset expiration)
+    pub ttl: u64,
 }
 
 /// A simplified price entry for external consumers.


### PR DESCRIPTION
# closes #28 
The TTL (Time-To-Live) per-asset expiration feature enables each asset in the price oracle to have its own independent validity window, allowing assets like NGN with faster market movements to expire in 1 hour while slower-moving assets like GHS can remain valid for 4 hours. Each `PriceData` entry now includes a `ttl: u64` field (in seconds), and the contract uses the `is_stale()` helper function to validate prices by comparing the current ledger timestamp against `stored_timestamp + ttl` if the current time has reached or exceeded this expiration point, the price is considered stale and will be rejected by `get_price()`. Both `set_price()` and `update_price()` now accept a `ttl` parameter to allow callers to specify the desired validity period for each price update, providing flexibility for different asset volatility profiles and data freshness requirements.