### PR TITLE
feat(price-oracle): add bulk get_prices endpoint (#82)

### DIFF
--- a/contracts/price-oracle/src/lib.rs
+++ b/contracts/price-oracle/src/lib.rs
@@ -29,6 +29,12 @@ pub trait StellarFlowTrait {
     /// This is the fastest getter for contracts that only need the price.
     fn get_last_price(env: Env, asset: Symbol) -> Result<i128, Error>;
 
+    /// Get prices for a list of assets in a single call.
+    ///
+    /// Returns a `Vec<PriceEntry>` in the same order as the input symbols.
+    /// Assets that are missing or stale are represented as `None` entries.
+    fn get_prices(env: Env, assets: soroban_sdk::Vec<Symbol>) -> soroban_sdk::Vec<Option<crate::types::PriceEntry>>;
+
     /// Get all currently tracked asset symbols.
     ///
     /// Returns a vector of all assets that have prices stored in the contract.
@@ -185,6 +191,41 @@ impl PriceOracle {
     pub fn get_last_price(env: Env, asset: Symbol) -> Result<i128, Error> {
         let price_data = Self::get_price(env, asset)?;
         Ok(price_data.price)
+    }
+
+    /// Get prices for a batch of assets in a single call.
+    ///
+    /// Returns a `Vec<Option<PriceEntry>>` in the same order as `assets`.
+    /// Each entry is `Some(PriceEntry)` when the asset exists and is not stale,
+    /// or `None` when it is missing or stale — matching `get_price_safe` semantics.
+    pub fn get_prices(
+        env: Env,
+        assets: soroban_sdk::Vec<Symbol>,
+    ) -> soroban_sdk::Vec<Option<crate::types::PriceEntry>> {
+        let prices: soroban_sdk::Map<Symbol, PriceData> = env
+            .storage()
+            .persistent()
+            .get(&DataKey::PriceData)
+            .unwrap_or_else(|| soroban_sdk::Map::new(&env));
+
+        let now = env.ledger().timestamp();
+        let mut result = soroban_sdk::Vec::new(&env);
+
+        for asset in assets.iter() {
+            let entry = prices.get(asset).and_then(|pd| {
+                if is_stale(now, pd.timestamp, pd.ttl) {
+                    None
+                } else {
+                    Some(crate::types::PriceEntry {
+                        price: pd.price,
+                        timestamp: pd.timestamp,
+                    })
+                }
+            });
+            result.push_back(entry);
+        }
+
+        result
     }
 
     /// Returns a vector of all currently tracked asset symbols.

--- a/contracts/price-oracle/src/test.rs
+++ b/contracts/price-oracle/src/test.rs
@@ -555,3 +555,111 @@ fn test_dummy_consumer_multiple_price_fetches() {
     assert_eq!(ngn_price_2, 1_200_000_i128);
     assert_eq!(kes_price_2, 450_000_i128);
 }
+
+// ============================================================================
+// Bulk get_prices Tests
+// ============================================================================
+
+#[test]
+fn test_get_prices_returns_all_requested_assets() {
+    let env = Env::default();
+    let contract_id = env.register(PriceOracle, ());
+    let client = PriceOracleClient::new(&env, &contract_id);
+
+    let ngn = symbol_short!("NGN");
+    let kes = symbol_short!("KES");
+    let ghs = symbol_short!("GHS");
+
+    env.ledger().set_timestamp(1_000_000);
+    env.ledger().set_sequence_number(1);
+    client.set_price(&ngn, &1_500_i128, &2u32, &3600u64);
+    client.set_price(&kes, &800_i128, &2u32, &3600u64);
+    client.set_price(&ghs, &5_000_i128, &2u32, &3600u64);
+
+    let assets = soroban_sdk::vec![&env, ngn.clone(), kes.clone(), ghs.clone()];
+    let results = client.get_prices(&assets);
+
+    assert_eq!(results.len(), 3);
+    assert_eq!(results.get(0).unwrap().unwrap().price, 1_500_i128);
+    assert_eq!(results.get(1).unwrap().unwrap().price, 800_i128);
+    assert_eq!(results.get(2).unwrap().unwrap().price, 5_000_i128);
+}
+
+#[test]
+fn test_get_prices_returns_none_for_missing_asset() {
+    let env = Env::default();
+    let contract_id = env.register(PriceOracle, ());
+    let client = PriceOracleClient::new(&env, &contract_id);
+
+    let ngn = symbol_short!("NGN");
+    let btc = symbol_short!("BTC"); // not stored
+
+    env.ledger().set_timestamp(1_000_000);
+    env.ledger().set_sequence_number(1);
+    client.set_price(&ngn, &1_500_i128, &2u32, &3600u64);
+
+    let assets = soroban_sdk::vec![&env, ngn.clone(), btc.clone()];
+    let results = client.get_prices(&assets);
+
+    assert_eq!(results.len(), 2);
+    assert!(results.get(0).unwrap().is_some());
+    assert!(results.get(1).unwrap().is_none()); // BTC missing → None
+}
+
+#[test]
+fn test_get_prices_returns_none_for_stale_asset() {
+    let env = Env::default();
+    let contract_id = env.register(PriceOracle, ());
+    let client = PriceOracleClient::new(&env, &contract_id);
+
+    let ngn = symbol_short!("NGN");
+
+    // Store price with a short TTL of 100 seconds
+    env.ledger().set_timestamp(1_000_000);
+    env.ledger().set_sequence_number(1);
+    client.set_price(&ngn, &1_500_i128, &2u32, &100u64);
+
+    // Advance time past TTL
+    env.ledger().set_timestamp(1_000_200);
+    env.ledger().set_sequence_number(2);
+
+    let assets = soroban_sdk::vec![&env, ngn.clone()];
+    let results = client.get_prices(&assets);
+
+    assert_eq!(results.len(), 1);
+    assert!(results.get(0).unwrap().is_none()); // stale → None
+}
+
+#[test]
+fn test_get_prices_preserves_order() {
+    let env = Env::default();
+    let contract_id = env.register(PriceOracle, ());
+    let client = PriceOracleClient::new(&env, &contract_id);
+
+    let ngn = symbol_short!("NGN");
+    let kes = symbol_short!("KES");
+
+    env.ledger().set_timestamp(1_000_000);
+    env.ledger().set_sequence_number(1);
+    client.set_price(&ngn, &111_i128, &2u32, &3600u64);
+    client.set_price(&kes, &222_i128, &2u32, &3600u64);
+
+    // Request in reverse order
+    let assets = soroban_sdk::vec![&env, kes.clone(), ngn.clone()];
+    let results = client.get_prices(&assets);
+
+    assert_eq!(results.get(0).unwrap().unwrap().price, 222_i128); // KES first
+    assert_eq!(results.get(1).unwrap().unwrap().price, 111_i128); // NGN second
+}
+
+#[test]
+fn test_get_prices_empty_input_returns_empty_vec() {
+    let env = Env::default();
+    let contract_id = env.register(PriceOracle, ());
+    let client = PriceOracleClient::new(&env, &contract_id);
+
+    let assets: soroban_sdk::Vec<Symbol> = soroban_sdk::vec![&env];
+    let results = client.get_prices(&assets);
+
+    assert_eq!(results.len(), 0);
+}


### PR DESCRIPTION
---

**Title:** `feat(price-oracle): bulk get_prices endpoint (#82)`
Closes #82
**Description:**

## What

Adds `get_prices(assets: Vec<Symbol>) -> Vec<Option<PriceEntry>>` to the `StellarFlowTrait` interface and implements it on `PriceOracle`.

## Why

Resolves #82. The dashboard was making one cross-contract call per asset to fetch rates. This endpoint collapses all of those into a single call, eliminating the round-trip overhead entirely.

## How

- The prices map is loaded from persistent storage exactly once per call.
- The result vector preserves the input order, so callers can zip it with their symbol list without extra lookups.
- Missing or stale assets return `None` (same semantics as `get_price_safe`), so callers get graceful degradation rather than a hard error.
- `PriceEntry` (already defined in `types.rs`) is the return type — just `price` + `timestamp`, keeping the response lean.

## Tests (5 new)

- happy path — all requested assets returned with correct values
- missing asset — `None` in the correct position
- stale asset — `None` when TTL has expired
- order preservation — result order matches input order regardless of storage order
- empty input — returns empty vec without panicking