### PR TITLE
Implement Delta Limit Circuit Breaker

### DIFF
--- a/contracts/price-oracle/src/lib.rs
+++ b/contracts/price-oracle/src/lib.rs
@@ -63,6 +63,8 @@ pub enum Error {
     NotAuthorized = 5,
     /// Contract or admin has already been initialized.
     AlreadyInitialized = 6,
+    /// Price change exceeds the allowed delta limit in a single update.
+    PriceDeltaExceeded = 7,
 }
 
 #[contract]
@@ -337,10 +339,19 @@ impl PriceOracle {
             .get(&DataKey::PriceData)
             .unwrap_or_else(|| soroban_sdk::Map::new(&env));
 
-        let _old_price = prices
+        let old_price = prices
             .get(asset.clone())
             .map(|existing_price| existing_price.price)
             .unwrap_or(0);
+
+        // Delta limit circuit breaker: reject if price moves more than 50 in one update.
+        // Skip on first write (old_price == 0).
+        if old_price != 0 {
+            let delta = (price - old_price).unsigned_abs();
+            if delta > 50 {
+                return Err(Error::PriceDeltaExceeded);
+            }
+        }
 
         let timestamp = env.ledger().timestamp();
         let price_data = PriceData {


### PR DESCRIPTION
Closes #78

---

feat(price-oracle): add delta limit circuit breaker

Adds a circuit breaker to update_price that rejects any single price update where the absolute change exceeds 50 units. This prevents runaway prices from being written to the oracle in a single block — whether from a compromised provider, a fat-finger, or a feed error.

What changed

New Error::PriceDeltaExceeded (code 7) returned when the delta check fails
update_price now reads the existing price before writing and computes |new_price - old_price|
If the delta is greater than 50, the transaction is rejected with PriceDeltaExceeded
First-time writes for an asset skip the check since there is no prior price to compare against
Behaviour

old → new of 100 → 149 passes (delta = 49)
old → new of 100 → 151 fails (delta = 51)
No prior price (first write) always passes