### PR TITLE
Setup initial test environment for ledger-time-helper contract

### DIFF
--- a/contracts/ledger-time-helper/src/lib.rs
+++ b/contracts/ledger-time-helper/src/lib.rs
@@ -10,15 +10,4 @@ pub fn current_ledger_timestamp(env: &Env) -> u64 {
     env.ledger().timestamp()
 }
 
-#[cfg(test)]
-mod tests {
-    use super::current_ledger_timestamp;
-    use soroban_sdk::{testutils::Ledger, Env};
-
-    #[test]
-    fn returns_mock_ledger_timestamp() {
-        let env = Env::default();
-        env.ledger().set_timestamp(1_700_000_123);
-        assert_eq!(current_ledger_timestamp(&env), 1_700_000_123);
-    }
-}
+mod test;

--- a/contracts/ledger-time-helper/src/test.rs
+++ b/contracts/ledger-time-helper/src/test.rs
@@ -1,0 +1,11 @@
+#![cfg(test)]
+
+use super::*;
+use soroban_sdk::{testutils::Ledger, Env};
+
+#[test]
+fn test_current_ledger_timestamp() {
+    let env = Env::default();
+    env.ledger().set_timestamp(1_700_000_123);
+    assert_eq!(current_ledger_timestamp(&env), 1_700_000_123);
+}


### PR DESCRIPTION
Closes #66

## 🧪 Setup: Initial Test Environment for `ledger-time-helper` Contract

Sets up a dedicated test module for the `ledger-time-helper` contract, following the same pattern as existing contracts (`hello-world` and `price-oracle`).

### Changes

**`contracts/ledger-time-helper/src/test.rs`** *(new)*
- Added `#![cfg(test)]` for test-only compilation
- Imported Soroban SDK types (`Env`, `testutils::Ledger`)
- Added test verifying `current_ledger_timestamp` works correctly

**`contracts/ledger-time-helper/src/lib.rs`**
- Replaced inline `mod tests` block with `mod test;` declaration referencing the new external test module