### PR TITLE
Organize contract data structures into types module

### DIFF
--- a/contracts/hello-world/src/lib.rs
+++ b/contracts/hello-world/src/lib.rs
@@ -1,8 +1,9 @@
 #![no_std]
-use soroban_sdk::{contract, contractimpl, vec, Env, String, Vec};
+use soroban_sdk::{contractimpl, vec, Env, String, Vec};
 
-#[contract]
-pub struct Contract;
+pub mod types;
+
+pub use crate::types::*;
 
 // This is a sample contract. Replace this placeholder with your own contract logic.
 // A corresponding test example is available in `test.rs`.

--- a/contracts/hello-world/src/types.rs
+++ b/contracts/hello-world/src/types.rs
@@ -1,0 +1,4 @@
+use soroban_sdk::contract;
+
+#[contract]
+pub struct Contract;


### PR DESCRIPTION

##  Summary
Closes #65.

This change organizes contract data structures into a dedicated `types` module and exposes it from `lib.rs`.

## Root Cause
The `hello-world` contract type was defined directly in `lib.rs` without a dedicated types module, leading to less structured organization.

## Fix Implemented
- Added `types.rs` and moved the `Contract` type into it
- Updated `lib.rs` to:
  - Declare `pub mod types`
  - Re-export type symbols for compatibility

## Testing Performed
- `cargo fmt -p hello-world -- --check` passed
- Attempted:
  - `cargo check`
  - `cargo test`
  - `cargo clippy`
- These were blocked due to a missing local MSVC linker (`link.exe`)
