### PR TITLE
feat: create is_whitelisted_provider helper as guard in update_price

### DIFF
--- a/contracts/price-oracle/src/lib.rs
+++ b/contracts/price-oracle/src/lib.rs
@@ -113,6 +113,10 @@ fn is_valid(price: i128) -> bool {
     price > 0
 }
 
+fn is_whitelisted_provider(env: &Env, source: &Address) -> bool {
+    crate::auth::_is_provider(env, source)
+}
+
 /// Check if a price entry is stale based on its TTL.
 ///
 /// A price is considered stale if the current ledger timestamp has passed
@@ -362,7 +366,7 @@ impl PriceOracle {
             return Err(Error::InvalidPrice);
         }
 
-        if !crate::auth::_is_provider(&env, &source) {
+        if !is_whitelisted_provider(&env, &source) {
             return Err(Error::NotAuthorized);
         }
 


### PR DESCRIPTION
Resolves #69 

### Description

This PR introduces the [is_whitelisted_provider](cci:1://file:///c:/Users/PC/OneDrive/Desktop/mmmm/stellarflow-contracts/contracts/price-oracle/src/lib.rs:115:0-117:1) private helper function to the [PriceOracle](cci:2://file:///c:/Users/PC/OneDrive/Desktop/mmmm/stellarflow-contracts/contracts/price-oracle/src/lib.rs:72:0-72:23) contract and implements it as a Guard within the [update_price](cci:1://file:///c:/Users/PC/OneDrive/Desktop/mmmm/stellarflow-contracts/contracts/price-oracle/src/lib.rs:333:4-426:5) function.

**Changes Made:**
- Created [is_whitelisted_provider](cci:1://file:///c:/Users/PC/OneDrive/Desktop/mmmm/stellarflow-contracts/contracts/price-oracle/src/lib.rs:115:0-117:1) helper inside [contracts/price-oracle/src/lib.rs](cci:7://file:///c:/Users/PC/OneDrive/Desktop/mmmm/stellarflow-contracts/contracts/price-oracle/src/lib.rs:0:0-0:0) which delegates to the `crate::auth::_is_provider` logic.
- Replaced the direct [_is_provider](cci:1://file:///c:/Users/PC/OneDrive/Desktop/mmmm/stellarflow-contracts/contracts/price-oracle/src/auth.rs:109:0-115:1) call with the new helper in [update_price](cci:1://file:///c:/Users/PC/OneDrive/Desktop/mmmm/stellarflow-contracts/contracts/price-oracle/src/lib.rs:333:4-426:5) to instantly verify relayers before processing any price data.

### Verification
- [x] Verified that the update appropriately blocks unauthorized non-white-listed relay providers from processing data.
- [x] Confirmed the guard successfully delegates to the correct authentication check logic within `auth.rs`.
