### PR TITLE
feat(price-oracle): add get_ledger_version function (#72)

### DIFF
--- a/contracts/price-oracle/src/lib.rs
+++ b/contracts/price-oracle/src/lib.rs
@@ -72,6 +72,12 @@ pub trait StellarFlowTrait {
     ///
     /// Returns a vector of the most recent events (max 5).
     fn get_last_n_events(env: Env, n: u32) -> soroban_sdk::Vec<RecentEvent>;
+
+    /// Get the current ledger sequence number.
+    ///
+    /// Useful for the frontend and backend to verify they are talking to the
+    /// correct version of the oracle and to track contract compatibility.
+    fn get_ledger_version(env: Env) -> u32;
 }
 
 /// Error types for the price oracle contract
@@ -665,6 +671,14 @@ impl PriceOracle {
             .get(&DataKey::PriceBoundsData)
             .unwrap_or_else(|| soroban_sdk::Map::new(&env));
         bounds_map.get(asset)
+    }
+
+    /// Get the current ledger sequence number.
+    ///
+    /// Returns the ledger sequence number at the time of the call.
+    /// Useful for the frontend and backend to verify contract compatibility.
+    pub fn get_ledger_version(env: Env) -> u32 {
+        env.ledger().sequence()
     }
 
     /// Get the last N activity events from the on-chain log.

--- a/contracts/price-oracle/src/test.rs
+++ b/contracts/price-oracle/src/test.rs
@@ -84,6 +84,16 @@ fn test_initialize_success() {
 }
 
 #[test]
+fn test_get_ledger_version_returns_sequence() {
+    let env = Env::default();
+    let contract_id = env.register(PriceOracle, ());
+    let client = PriceOracleClient::new(&env, &contract_id);
+
+    env.ledger().set_sequence_number(42);
+    assert_eq!(client.get_ledger_version(), 42);
+}
+
+#[test]
 #[should_panic]
 fn test_initialize_double_panics() {
     let env = Env::default();


### PR DESCRIPTION
                                                                                                                               
  Closes #72                                                                                                                                               
                                                                                                                                                          
  What                                                                                                                                                    
                                                                                                                                                          
  Adds a public get_ledger_version() function to the price oracle contract that returns the current ledger sequence number.                               
                                                                                                                                                          
  Why                                                                                                                                                     
                                                                                                                                                          
  Gives the frontend and backend a lightweight way to verify they are talking to the correct version of the oracle before making price queries.           
                                                                                                                                                          
  Changes                                                                                                                                                 
                                                                                                                                                          
  - Added get_ledger_version() -> u32 to StellarFlowTrait interface                                                                                       
  - Implemented in PriceOracle via env.ledger().sequence()                                                                                                
  - Added test_get_ledger_version_returns_sequence test                                                                                                   
                     