### PR TITLE
feat: add rescue_tokens functionality to recover trapped assets

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,8 @@ soroban contract build
 
 > add_provider(provider: Address): Whitelists a backend relayer to push data.
 
+> rescue_tokens(token: Address, to: Address, amount: i128): Admin-only function to recover trapped assets from the contract.
+
 **Data Submission (Authorized)**
 update_price(source: Address, asset: Symbol, price: i128): Updates the price for a specific asset. Requires source authorization.
 

--- a/contracts/price-oracle/src/lib.rs
+++ b/contracts/price-oracle/src/lib.rs
@@ -83,6 +83,11 @@ pub trait StellarFlowTrait {
     /// Useful for the frontend and backend to verify they are talking to the
     /// correct version of the oracle and to track contract compatibility.
     fn get_ledger_version(env: Env) -> u32;
+
+    /// Rescue tokens accidentally sent to this contract.
+    ///
+    /// Only the authorized admin may call this function.
+    fn rescue_tokens(env: Env, admin: Address, token: Address, to: Address, amount: i128);
 }
 
 /// Error types for the price oracle contract
@@ -136,6 +141,19 @@ pub struct ContractInitialized {
 #[soroban_sdk::contractevent]
 pub struct AssetAddedEvent {
     pub symbol: Symbol,
+}
+
+#[soroban_sdk::contractevent]
+pub struct RescueTokensEvent {
+    pub token: Address,
+    pub recipient: Address,
+    pub amount: i128,
+}
+
+/// Generic token contract client interface used to send recovered assets to a safe address.
+#[contractclient(name = "TokenContractClient")]
+pub trait TokenContract {
+    fn transfer(env: Env, from: Address, to: Address, amount: i128);
 }
 
 /// Returns the signed percentage change in basis points.
@@ -546,6 +564,27 @@ impl PriceOracle {
         } else {
             log_event(&env, Symbol::new(&env, "price_updated"), asset, val);
         }
+    }
+
+    /// Rescue tokens accidentally sent to this contract.
+    ///
+    /// Admin-only function to move trapped XLM or other assets out of the contract.
+    pub fn rescue_tokens(env: Env, admin: Address, token: Address, to: Address, amount: i128) {
+        admin.require_auth();
+        crate::auth::_require_authorized(&env, &admin);
+
+        if amount <= 0 {
+            panic_with_error!(&env, Error::InvalidPrice);
+        }
+
+        let token_client = TokenContractClient::new(&env, &token);
+        token_client.transfer(&env.current_contract_address(), &to, &amount);
+
+        env.events().publish_event(&RescueTokensEvent {
+            token,
+            recipient: to,
+            amount,
+        });
     }
 
     /// Upgrade the contract WASM code.

--- a/contracts/price-oracle/src/test.rs
+++ b/contracts/price-oracle/src/test.rs
@@ -55,6 +55,24 @@ impl DummyConsumer {
     }
 }
 
+#[soroban_sdk::contractevent]
+pub struct TokenTransferEvent {
+    pub from: Address,
+    pub to: Address,
+    pub amount: i128,
+}
+
+#[contract]
+pub struct DummyToken;
+
+#[contractimpl]
+impl DummyToken {
+    pub fn transfer(env: Env, from: Address, to: Address, amount: i128) {
+        from.require_auth();
+        env.events().publish_event(&TokenTransferEvent { from, to, amount });
+    }
+}
+
 #[test]
 fn test_initialize_success() {
     let env = Env::default();
@@ -399,6 +417,52 @@ fn test_update_price_admin_authority() {
         Err(Ok(e)) => assert_eq!(e, Error::NotAuthorized),
         other => panic!("expected NotAuthorized, got {:?}", other),
     }
+}
+
+#[test]
+fn test_rescue_tokens_admin_can_recover_assets() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let contract_id = env.register(PriceOracle, ());
+    let client = PriceOracleClient::new(&env, &contract_id);
+    let token_id = env.register(DummyToken, ());
+
+    let admin = <soroban_sdk::Address as soroban_sdk::testutils::Address>::generate(&env);
+    let recipient = <soroban_sdk::Address as soroban_sdk::testutils::Address>::generate(&env);
+
+    env.as_contract(&contract_id, || {
+        crate::auth::_set_admin(&env, &soroban_sdk::vec![&env, admin.clone()]);
+    });
+
+    client.rescue_tokens(&admin, &token_id, &recipient, &1_000_i128);
+
+    let events = env.events().all();
+    let debug_str = alloc::format!("{:?}", events);
+    assert!(debug_str.contains("TokenTransferEvent"));
+    assert!(debug_str.contains(&format!("{:?}", recipient)));
+    assert!(debug_str.contains(&format!("{:?}", 1_000_i128)));
+}
+
+#[test]
+#[should_panic(expected = "Unauthorised: caller is not in the authorized admin list")]
+fn test_rescue_tokens_rejects_non_admin() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let contract_id = env.register(PriceOracle, ());
+    let client = PriceOracleClient::new(&env, &contract_id);
+    let token_id = env.register(DummyToken, ());
+
+    let admin = <soroban_sdk::Address as soroban_sdk::testutils::Address>::generate(&env);
+    let non_admin = <soroban_sdk::Address as soroban_sdk::testutils::Address>::generate(&env);
+    let recipient = <soroban_sdk::Address as soroban_sdk::testutils::Address>::generate(&env);
+
+    env.as_contract(&contract_id, || {
+        crate::auth::_set_admin(&env, &soroban_sdk::vec![&env, admin.clone()]);
+    });
+
+    client.rescue_tokens(&non_admin, &token_id, &recipient, &1_000_i128);
 }
 
 #[test]


### PR DESCRIPTION
Closes #135 

Changes implemented
[lib.rs](vscode-file://vscode-app/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html)

Added [rescue_tokens(env, admin, token, to, amount)](vscode-file://vscode-app/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) to the [StellarFlowClient](vscode-file://vscode-app/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) trait.
Added RescueTokensEvent for transparency.
Added a generic [TokenContractClient](vscode-file://vscode-app/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) cross-contract interface.
Implemented admin-only token rescue logic with auth checks and positive-amount validation.
[test.rs](vscode-file://vscode-app/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html)

Added [DummyToken](vscode-file://vscode-app/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) contract and TokenTransferEvent.
Added tests:
[test_rescue_tokens_admin_can_recover_assets](vscode-file://vscode-app/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html)
[test_rescue_tokens_rejects_non_admin](vscode-file://vscode-app/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html)
[README.md](vscode-file://vscode-app/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html)

Documented the new [rescue_tokens(token: Address, to: Address, amount: i128)](vscode-file://vscode-app/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) admin recovery API.