### PR TITLE
fix: add stale-status oracle getters for graceful degradation

### DIFF
--- a/contracts/price-oracle/src/lib.rs
+++ b/contracts/price-oracle/src/lib.rs
@@ -2,7 +2,7 @@
 
 use soroban_sdk::{contract, contractclient, contracterror, contractimpl, panic_with_error, Address, Env, Symbol};
 
-use crate::types::{DataKey, PriceBounds, PriceData};
+use crate::types::{DataKey, PriceBounds, PriceData, PriceDataWithStatus, PriceEntryWithStatus};
 
 /// A clean, gas-optimized interface for other Soroban contracts to fetch prices from StellarFlow.
 ///
@@ -16,6 +16,11 @@ pub trait StellarFlowTrait {
     /// Returns the complete price information including timestamp, decimals, confidence score, and TTL.
     /// Returns `Error::AssetNotFound` if the asset does not exist or the price is stale.
     fn get_price(env: Env, asset: Symbol) -> Result<PriceData, Error>;
+
+    /// Get the full price data with freshness status for a specific asset.
+    ///
+    /// Returns the last known price with `is_stale = true` when the price has expired.
+    fn get_price_with_status(env: Env, asset: Symbol) -> Result<PriceDataWithStatus, Error>;
 
     /// Get the price data for a specific asset, or `None` if not found.
     ///
@@ -33,7 +38,18 @@ pub trait StellarFlowTrait {
     ///
     /// Returns a `Vec<PriceEntry>` in the same order as the input symbols.
     /// Assets that are missing or stale are represented as `None` entries.
-    fn get_prices(env: Env, assets: soroban_sdk::Vec<Symbol>) -> soroban_sdk::Vec<Option<crate::types::PriceEntry>>;
+    fn get_prices(
+        env: Env,
+        assets: soroban_sdk::Vec<Symbol>,
+    ) -> soroban_sdk::Vec<Option<crate::types::PriceEntry>>;
+
+    /// Get prices for a list of assets with freshness status.
+    ///
+    /// Returns the last known price for stale entries and marks them with `is_stale = true`.
+    fn get_prices_with_status(
+        env: Env,
+        assets: soroban_sdk::Vec<Symbol>,
+    ) -> soroban_sdk::Vec<Option<PriceEntryWithStatus>>;
 
     /// Get all currently tracked asset symbols.
     ///
@@ -187,6 +203,26 @@ impl PriceOracle {
         }
     }
 
+    /// Returns the last known price data and marks it stale when TTL has expired.
+    pub fn get_price_with_status(env: Env, asset: Symbol) -> Result<PriceDataWithStatus, Error> {
+        let prices: soroban_sdk::Map<Symbol, PriceData> = env
+            .storage()
+            .persistent()
+            .get(&DataKey::PriceData)
+            .unwrap_or_else(|| soroban_sdk::Map::new(&env));
+
+        match prices.get(asset) {
+            Some(price_data) => {
+                let now = env.ledger().timestamp();
+                Ok(PriceDataWithStatus {
+                    is_stale: is_stale(now, price_data.timestamp, price_data.ttl),
+                    data: price_data,
+                })
+            }
+            None => Err(Error::AssetNotFound),
+        }
+    }
+
     /// Returns `None` instead of an error when the asset is not found.
     pub fn get_price_safe(env: Env, asset: Symbol) -> Option<PriceData> {
         let prices: soroban_sdk::Map<Symbol, PriceData> = env
@@ -233,6 +269,32 @@ impl PriceOracle {
                         timestamp: pd.timestamp,
                     })
                 }
+            });
+            result.push_back(entry);
+        }
+
+        result
+    }
+
+    /// Returns prices for all found assets and marks stale entries with `is_stale = true`.
+    pub fn get_prices_with_status(
+        env: Env,
+        assets: soroban_sdk::Vec<Symbol>,
+    ) -> soroban_sdk::Vec<Option<PriceEntryWithStatus>> {
+        let prices: soroban_sdk::Map<Symbol, PriceData> = env
+            .storage()
+            .persistent()
+            .get(&DataKey::PriceData)
+            .unwrap_or_else(|| soroban_sdk::Map::new(&env));
+
+        let now = env.ledger().timestamp();
+        let mut result = soroban_sdk::Vec::new(&env);
+
+        for asset in assets.iter() {
+            let entry = prices.get(asset).map(|pd| PriceEntryWithStatus {
+                price: pd.price,
+                timestamp: pd.timestamp,
+                is_stale: is_stale(now, pd.timestamp, pd.ttl),
             });
             result.push_back(entry);
         }

--- a/contracts/price-oracle/src/test.rs
+++ b/contracts/price-oracle/src/test.rs
@@ -215,6 +215,44 @@ fn test_get_price_after_update() {
 }
 
 #[test]
+fn test_get_price_with_status_marks_stale_entry() {
+    let env = Env::default();
+    let contract_id = env.register(PriceOracle, ());
+    let client = PriceOracleClient::new(&env, &contract_id);
+    let asset = symbol_short!("NGN");
+
+    env.ledger().set_timestamp(1_000_000);
+    env.ledger().set_sequence_number(1);
+    client.set_price(&asset, &1_500_i128, &2u32, &100u64);
+
+    env.ledger().set_timestamp(1_000_200);
+    env.ledger().set_sequence_number(2);
+
+    let result = client.get_price_with_status(&asset);
+    assert_eq!(result.data.price, 1_500_i128);
+    assert!(result.is_stale);
+}
+
+#[test]
+fn test_get_price_with_status_marks_fresh_entry() {
+    let env = Env::default();
+    let contract_id = env.register(PriceOracle, ());
+    let client = PriceOracleClient::new(&env, &contract_id);
+    let asset = symbol_short!("NGN");
+
+    env.ledger().set_timestamp(1_000_000);
+    env.ledger().set_sequence_number(1);
+    client.set_price(&asset, &1_500_i128, &2u32, &100u64);
+
+    env.ledger().set_timestamp(1_000_050);
+    env.ledger().set_sequence_number(2);
+
+    let result = client.get_price_with_status(&asset);
+    assert_eq!(result.data.price, 1_500_i128);
+    assert!(!result.is_stale);
+}
+
+#[test]
 fn test_get_price_safe_nonexistent_returns_none() {
     let (_, client) = setup();
     assert_eq!(client.get_price_safe(&symbol_short!("NGN")), None);
@@ -808,6 +846,51 @@ fn test_get_prices_empty_input_returns_empty_vec() {
     let results = client.get_prices(&assets);
 
     assert_eq!(results.len(), 0);
+}
+
+#[test]
+fn test_get_prices_with_status_marks_stale_entry() {
+    let env = Env::default();
+    let contract_id = env.register(PriceOracle, ());
+    let client = PriceOracleClient::new(&env, &contract_id);
+
+    let ngn = symbol_short!("NGN");
+
+    env.ledger().set_timestamp(1_000_000);
+    env.ledger().set_sequence_number(1);
+    client.set_price(&ngn, &1_500_i128, &2u32, &100u64);
+
+    env.ledger().set_timestamp(1_000_200);
+    env.ledger().set_sequence_number(2);
+
+    let assets = soroban_sdk::vec![&env, ngn.clone()];
+    let results = client.get_prices_with_status(&assets);
+
+    assert_eq!(results.len(), 1);
+    let entry = results.get(0).unwrap().unwrap();
+    assert_eq!(entry.price, 1_500_i128);
+    assert!(entry.is_stale);
+}
+
+#[test]
+fn test_get_prices_with_status_returns_none_for_missing_asset() {
+    let env = Env::default();
+    let contract_id = env.register(PriceOracle, ());
+    let client = PriceOracleClient::new(&env, &contract_id);
+
+    let ngn = symbol_short!("NGN");
+    let btc = symbol_short!("BTC");
+
+    env.ledger().set_timestamp(1_000_000);
+    env.ledger().set_sequence_number(1);
+    client.set_price(&ngn, &1_500_i128, &2u32, &3600u64);
+
+    let assets = soroban_sdk::vec![&env, ngn.clone(), btc.clone()];
+    let results = client.get_prices_with_status(&assets);
+
+    assert_eq!(results.len(), 2);
+    assert!(results.get(0).unwrap().is_some());
+    assert!(results.get(1).unwrap().is_none());
 }
 
 // ============================================================================

--- a/contracts/price-oracle/src/types.rs
+++ b/contracts/price-oracle/src/types.rs
@@ -35,6 +35,23 @@ pub struct PriceEntry {
     pub timestamp: u64,
 }
 
+/// Full price payload returned to consumers with freshness status.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct PriceDataWithStatus {
+    pub data: PriceData,
+    pub is_stale: bool,
+}
+
+/// Lightweight price payload returned to consumers with freshness status.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct PriceEntryWithStatus {
+    pub price: i128,
+    pub timestamp: u64,
+    pub is_stale: bool,
+}
+
 /// Min/max price bounds for an asset to prevent fat-finger errors.
 #[contracttype]
 #[derive(Clone, Debug, Eq, PartialEq)]


### PR DESCRIPTION

# Closes #130

## Summary

The issue requires graceful degradation so stale prices remain usable, with explicit stale signaling for integrators.

## Root Cause

The current strict read paths treat stale prices as unavailable, either by returning `AssetNotFound` or `None`, and do not provide an explicit `is_stale` field for those responses.

## Fix Implemented

- Added `get_price_with_status` — returns the last known price payload plus `is_stale`
- Added `get_prices_with_status` — returns per-asset entries with `is_stale` for found assets, including stale ones
- Existing getters left unchanged to preserve backward compatibility

## Testing Performed

- Added targeted unit tests for stale and fresh status behavior on single and batch status-aware getters
- Ran `cargo fmt` successfully
- Attempted `cargo test -p price-oracle` — blocked by local Windows linker/toolchain configuration, not by contract code diagnostics

- Closes #130