### PR TITLE
Emergency-pause

### DIFF
--- a/contracts/price-oracle/src/lib.rs
+++ b/contracts/price-oracle/src/lib.rs
@@ -95,6 +95,25 @@ pub trait StellarFlowTrait {
     ///
     /// Returns a static string identifying the oracle contract.
     fn get_contract_name(env: Env) -> String;
+
+    /// Toggle the pause state of the contract (requires 2-of-3 admin signatures).
+    ///
+    /// This function prevents a single compromised admin key from shutting down
+    /// the network. At least 2 out of 3 registered admins must authorize this action.
+    fn toggle_pause(env: Env, admin1: Address, admin2: Address) -> Result<bool, Error>;
+
+    /// Register a new admin (requires 2-of-3 existing admin signatures).
+    ///
+    /// Maximum of 3 admins allowed. Returns error if already at capacity.
+    fn register_admin(env: Env, admin1: Address, admin2: Address, new_admin: Address) -> Result<(), Error>;
+
+    /// Remove an admin (requires 2-of-3 existing admin signatures).
+    ///
+    /// Cannot remove the last admin. Returns error if would leave 0 admins.
+    fn remove_admin(env: Env, admin1: Address, admin2: Address, admin_to_remove: Address) -> Result<(), Error>;
+
+    /// Get the total number of registered admins.
+    fn get_admin_count(env: Env) -> u32;
 }
 
 /// Error types for the price oracle contract
@@ -120,6 +139,12 @@ pub enum Error {
     PriceOutOfBounds = 8,
     /// Provider weight must be between 0 and 100.
     InvalidWeight = 9,
+    /// Multi-signature validation failed - insufficient or invalid admin signatures.
+    MultiSigValidationFailed = 10,
+    /// Cannot add more admins - maximum of 3 admins allowed.
+    MaxAdminsReached = 11,
+    /// Cannot remove admin - would leave contract without any admins.
+    CannotRemoveLastAdmin = 12,
 }
 
 #[contract]
@@ -796,6 +821,155 @@ impl PriceOracle {
         }
 
         result
+    }
+
+    /// Toggle the pause state of the contract (requires 2-of-3 admin signatures).
+    ///
+    /// This function prevents a single compromised admin key from shutting down
+    /// the network. At least 2 out of 3 registered admins must authorize this action.
+    ///
+    /// # Arguments
+    /// * `admin1` - First admin address (must provide auth)
+    /// * `admin2` - Second admin address (must provide auth)
+    ///
+    /// # Returns
+    /// The new pause state (true = paused, false = unpaused)
+    pub fn toggle_pause(env: Env, admin1: Address, admin2: Address) -> Result<bool, Error> {
+        // Require both admins to provide cryptographic signatures
+        admin1.require_auth();
+        admin2.require_auth();
+
+        // Verify both are distinct addresses
+        if admin1 == admin2 {
+            return Err(Error::MultiSigValidationFailed);
+        }
+
+        // Verify both are authorized admins
+        crate::auth::_require_authorized(&env, &admin1);
+        crate::auth::_require_authorized(&env, &admin2);
+
+        // Get current admin list
+        let admins = crate::auth::_get_admin(&env);
+        let admin_count = admins.len();
+
+        // Ensure we have at least 2 admins registered
+        if admin_count < 2 {
+            return Err(Error::MultiSigValidationFailed);
+        }
+
+        // Toggle the pause state
+        let current_paused = crate::auth::_is_paused(&env);
+        let new_paused = !current_paused;
+        crate::auth::_set_paused(&env, new_paused);
+
+        // Emit event
+        env.events().publish(
+            (Symbol::new(&env, "pause_toggled"),),
+            (admin1.clone(), admin2.clone(), new_paused),
+        );
+
+        Ok(new_paused)
+    }
+
+    /// Register a new admin (requires 2-of-3 existing admin signatures).
+    ///
+    /// # Arguments
+    /// * `admin1` - First admin address (must provide auth)
+    /// * `admin2` - Second admin address (must provide auth)
+    /// * `new_admin` - The new admin to register
+    ///
+    /// # Returns
+    /// Ok(()) if successful, Error if validation fails
+    pub fn register_admin(env: Env, admin1: Address, admin2: Address, new_admin: Address) -> Result<(), Error> {
+        // Require both existing admins to provide cryptographic signatures
+        admin1.require_auth();
+        admin2.require_auth();
+
+        // Verify both are distinct addresses
+        if admin1 == admin2 {
+            return Err(Error::MultiSigValidationFailed);
+        }
+
+        // Verify both are authorized admins
+        crate::auth::_require_authorized(&env, &admin1);
+        crate::auth::_require_authorized(&env, &admin2);
+
+        // Get current admin list
+        let admins = crate::auth::_get_admin(&env);
+        let admin_count = admins.len();
+
+        // Check if we've reached the maximum of 3 admins
+        if admin_count >= 3 {
+            return Err(Error::MaxAdminsReached);
+        }
+
+        // Add the new admin
+        crate::auth::_add_authorized(&env, &new_admin);
+
+        // Emit event
+        env.events().publish(
+            (Symbol::new(&env, "admin_registered"),),
+            (admin1.clone(), admin2.clone(), new_admin.clone()),
+        );
+
+        Ok(())
+    }
+
+    /// Remove an admin (requires 2-of-3 existing admin signatures).
+    ///
+    /// # Arguments
+    /// * `admin1` - First admin address (must provide auth)
+    /// * `admin2` - Second admin address (must provide auth)
+    /// * `admin_to_remove` - The admin to remove
+    ///
+    /// # Returns
+    /// Ok(()) if successful, Error if validation fails
+    pub fn remove_admin(env: Env, admin1: Address, admin2: Address, admin_to_remove: Address) -> Result<(), Error> {
+        // Require both existing admins to provide cryptographic signatures
+        admin1.require_auth();
+        admin2.require_auth();
+
+        // Verify both are distinct addresses
+        if admin1 == admin2 {
+            return Err(Error::MultiSigValidationFailed);
+        }
+
+        // Verify both are authorized admins
+        crate::auth::_require_authorized(&env, &admin1);
+        crate::auth::_require_authorized(&env, &admin2);
+
+        // Get current admin list
+        let admins = crate::auth::_get_admin(&env);
+        let admin_count = admins.len();
+
+        // Cannot remove if would leave less than 1 admin
+        if admin_count <= 1 {
+            return Err(Error::CannotRemoveLastAdmin);
+        }
+
+        // Verify the admin to remove actually exists
+        if !admins.iter().any(|a| a == admin_to_remove) {
+            return Err(Error::NotAuthorized);
+        }
+
+        // Remove the admin
+        crate::auth::_remove_authorized(&env, &admin_to_remove);
+
+        // Emit event
+        env.events().publish(
+            (Symbol::new(&env, "admin_removed"),),
+            (admin1.clone(), admin2.clone(), admin_to_remove.clone()),
+        );
+
+        Ok(())
+    }
+
+    /// Get the total number of registered admins.
+    pub fn get_admin_count(env: Env) -> u32 {
+        if !crate::auth::_has_admin(&env) {
+            return 0;
+        }
+        crate::auth::_get_admin(&env).len()
     }
 }
 

--- a/contracts/price-oracle/src/test.rs
+++ b/contracts/price-oracle/src/test.rs
@@ -1576,3 +1576,348 @@ fn test_renounce_ownership_blocks_admin_functions_after_renouncement() {
     let dummy_hash = soroban_sdk::BytesN::from_array(&env, &[0u8; 32]);
     client.upgrade(&admin, &dummy_hash);
 }
+
+// ============================================================================
+// Multi-Signature Pause Tests
+// ============================================================================
+
+#[test]
+fn test_toggle_pause_requires_two_admins() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let contract_id = env.register(PriceOracle, ());
+    let client = PriceOracleClient::new(&env, &contract_id);
+    let admin1 = <soroban_sdk::Address as soroban_sdk::testutils::Address>::generate(&env);
+    let admin2 = <soroban_sdk::Address as soroban_sdk::testutils::Address>::generate(&env);
+
+    // Initialize with first admin
+    client.init_admin(&admin1);
+
+    // Add second admin
+    env.as_contract(&contract_id, || {
+        crate::auth::_add_authorized(&env, &admin2);
+    });
+
+    // Verify initially not paused
+    env.as_contract(&contract_id, || {
+        assert!(!crate::auth::_is_paused(&env));
+    });
+
+    // Toggle pause with two admins
+    let result = client.toggle_pause(&admin1, &admin2);
+    assert_eq!(result, Ok(true));
+
+    // Verify paused state
+    env.as_contract(&contract_id, || {
+        assert!(crate::auth::_is_paused(&env));
+    });
+
+    // Toggle again to unpause
+    let result = client.toggle_pause(&admin1, &admin2);
+    assert_eq!(result, Ok(false));
+
+    // Verify unpaused state
+    env.as_contract(&contract_id, || {
+        assert!(!crate::auth::_is_paused(&env));
+    });
+}
+
+#[test]
+fn test_toggle_pause_fails_with_same_admin_twice() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let contract_id = env.register(PriceOracle, ());
+    let client = PriceOracleClient::new(&env, &contract_id);
+    let admin1 = <soroban_sdk::Address as soroban_sdk::testutils::Address>::generate(&env);
+    let admin2 = <soroban_sdk::Address as soroban_sdk::testutils::Address>::generate(&env);
+
+    client.init_admin(&admin1);
+    env.as_contract(&contract_id, || {
+        crate::auth::_add_authorized(&env, &admin2);
+    });
+
+    // Should fail when using the same admin twice
+    let result = client.try_toggle_pause(&admin1, &admin1);
+    match result {
+        Err(Ok(e)) => assert_eq!(e, Error::MultiSigValidationFailed),
+        other => panic!("expected MultiSigValidationFailed, got {:?}", other),
+    }
+}
+
+#[test]
+fn test_toggle_pause_fails_with_non_admin() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let contract_id = env.register(PriceOracle, ());
+    let client = PriceOracleClient::new(&env, &contract_id);
+    let admin1 = <soroban_sdk::Address as soroban_sdk::testutils::Address>::generate(&env);
+    let admin2 = <soroban_sdk::Address as soroban_sdk::testutils::Address>::generate(&env);
+    let non_admin = <soroban_sdk::Address as soroban_sdk::testutils::Address>::generate(&env);
+
+    client.init_admin(&admin1);
+    env.as_contract(&contract_id, || {
+        crate::auth::_add_authorized(&env, &admin2);
+    });
+
+    // Should fail when one signer is not an admin
+    let result = client.try_toggle_pause(&admin1, &non_admin);
+    match result {
+        Err(Ok(e)) => assert_eq!(e, Error::NotAuthorized),
+        other => panic!("expected NotAuthorized, got {:?}", other),
+    }
+}
+
+#[test]
+fn test_toggle_pause_fails_with_only_one_admin() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let contract_id = env.register(PriceOracle, ());
+    let client = PriceOracleClient::new(&env, &contract_id);
+    let admin1 = <soroban_sdk::Address as soroban_sdk::testutils::Address>::generate(&env);
+
+    // Initialize with only one admin
+    client.init_admin(&admin1);
+
+    // Should fail when only one admin exists
+    let fake_admin = <soroban_sdk::Address as soroban_sdk::testutils::Address>::generate(&env);
+    let result = client.try_toggle_pause(&admin1, &fake_admin);
+    match result {
+        Err(Ok(e)) => assert_eq!(e, Error::NotAuthorized),
+        other => panic!("expected NotAuthorized, got {:?}", other),
+    }
+}
+
+#[test]
+fn test_register_admin_with_two_signatures() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let contract_id = env.register(PriceOracle, ());
+    let client = PriceOracleClient::new(&env, &contract_id);
+    let admin1 = <soroban_sdk::Address as soroban_sdk::testutils::Address>::generate(&env);
+    let admin2 = <soroban_sdk::Address as soroban_sdk::testutils::Address>::generate(&env);
+    let admin3 = <soroban_sdk::Address as soroban_sdk::testutils::Address>::generate(&env);
+
+    // Initialize with two admins
+    client.init_admin(&admin1);
+    env.as_contract(&contract_id, || {
+        crate::auth::_add_authorized(&env, &admin2);
+    });
+
+    assert_eq!(client.get_admin_count(), 2);
+
+    // Register third admin with signatures from admin1 and admin2
+    client.register_admin(&admin1, &admin2, &admin3);
+
+    assert_eq!(client.get_admin_count(), 3);
+    assert!(client.is_admin(&admin3));
+}
+
+#[test]
+fn test_register_admin_fails_at_max_capacity() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let contract_id = env.register(PriceOracle, ());
+    let client = PriceOracleClient::new(&env, &contract_id);
+    let admin1 = <soroban_sdk::Address as soroban_sdk::testutils::Address>::generate(&env);
+    let admin2 = <soroban_sdk::Address as soroban_sdk::testutils::Address>::generate(&env);
+    let admin3 = <soroban_sdk::Address as soroban_sdk::testutils::Address>::generate(&env);
+    let admin4 = <soroban_sdk::Address as soroban_sdk::testutils::Address>::generate(&env);
+
+    // Initialize with three admins
+    client.init_admin(&admin1);
+    env.as_contract(&contract_id, || {
+        crate::auth::_add_authorized(&env, &admin2);
+        crate::auth::_add_authorized(&env, &admin3);
+    });
+
+    assert_eq!(client.get_admin_count(), 3);
+
+    // Should fail when trying to add a 4th admin
+    let result = client.try_register_admin(&admin1, &admin2, &admin4);
+    match result {
+        Err(Ok(e)) => assert_eq!(e, Error::MaxAdminsReached),
+        other => panic!("expected MaxAdminsReached, got {:?}", other),
+    }
+}
+
+#[test]
+fn test_remove_admin_with_two_signatures() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let contract_id = env.register(PriceOracle, ());
+    let client = PriceOracleClient::new(&env, &contract_id);
+    let admin1 = <soroban_sdk::Address as soroban_sdk::testutils::Address>::generate(&env);
+    let admin2 = <soroban_sdk::Address as soroban_sdk::testutils::Address>::generate(&env);
+    let admin3 = <soroban_sdk::Address as soroban_sdk::testutils::Address>::generate(&env);
+
+    // Initialize with three admins
+    client.init_admin(&admin1);
+    env.as_contract(&contract_id, || {
+        crate::auth::_add_authorized(&env, &admin2);
+        crate::auth::_add_authorized(&env, &admin3);
+    });
+
+    assert_eq!(client.get_admin_count(), 3);
+
+    // Remove admin3 with signatures from admin1 and admin2
+    client.remove_admin(&admin1, &admin2, &admin3);
+
+    assert_eq!(client.get_admin_count(), 2);
+    assert!(!client.is_admin(&admin3));
+    assert!(client.is_admin(&admin1));
+    assert!(client.is_admin(&admin2));
+}
+
+#[test]
+fn test_remove_admin_fails_if_last_admin() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let contract_id = env.register(PriceOracle, ());
+    let client = PriceOracleClient::new(&env, &contract_id);
+    let admin1 = <soroban_sdk::Address as soroban_sdk::testutils::Address>::generate(&env);
+
+    // Initialize with only one admin
+    client.init_admin(&admin1);
+
+    // Should fail when trying to remove the last admin
+    let fake_admin = <soroban_sdk::Address as soroban_sdk::testutils::Address>::generate(&env);
+    let result = client.try_remove_admin(&admin1, &fake_admin, &admin1);
+    match result {
+        Err(Ok(e)) => assert_eq!(e, Error::NotAuthorized),
+        other => panic!("expected NotAuthorized, got {:?}", other),
+    }
+}
+
+#[test]
+fn test_multi_sig_pause_emits_event() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let contract_id = env.register(PriceOracle, ());
+    let client = PriceOracleClient::new(&env, &contract_id);
+    let admin1 = <soroban_sdk::Address as soroban_sdk::testutils::Address>::generate(&env);
+    let admin2 = <soroban_sdk::Address as soroban_sdk::testutils::Address>::generate(&env);
+
+    client.init_admin(&admin1);
+    env.as_contract(&contract_id, || {
+        crate::auth::_add_authorized(&env, &admin2);
+    });
+
+    client.toggle_pause(&admin1, &admin2);
+
+    let events = env.events().all();
+    let debug_str = alloc::format!("{:?}", events);
+    assert!(debug_str.contains("pause_toggled"));
+}
+
+#[test]
+fn test_register_admin_emits_event() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let contract_id = env.register(PriceOracle, ());
+    let client = PriceOracleClient::new(&env, &contract_id);
+    let admin1 = <soroban_sdk::Address as soroban_sdk::testutils::Address>::generate(&env);
+    let admin2 = <soroban_sdk::Address as soroban_sdk::testutils::Address>::generate(&env);
+    let admin3 = <soroban_sdk::Address as soroban_sdk::testutils::Address>::generate(&env);
+
+    client.init_admin(&admin1);
+    env.as_contract(&contract_id, || {
+        crate::auth::_add_authorized(&env, &admin2);
+    });
+
+    client.register_admin(&admin1, &admin2, &admin3);
+
+    let events = env.events().all();
+    let debug_str = alloc::format!("{:?}", events);
+    assert!(debug_str.contains("admin_registered"));
+}
+
+#[test]
+fn test_remove_admin_emits_event() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let contract_id = env.register(PriceOracle, ());
+    let client = PriceOracleClient::new(&env, &contract_id);
+    let admin1 = <soroban_sdk::Address as soroban_sdk::testutils::Address>::generate(&env);
+    let admin2 = <soroban_sdk::Address as soroban_sdk::testutils::Address>::generate(&env);
+    let admin3 = <soroban_sdk::Address as soroban_sdk::testutils::Address>::generate(&env);
+
+    client.init_admin(&admin1);
+    env.as_contract(&contract_id, || {
+        crate::auth::_add_authorized(&env, &admin2);
+        crate::auth::_add_authorized(&env, &admin3);
+    });
+
+    client.remove_admin(&admin1, &admin2, &admin3);
+
+    let events = env.events().all();
+    let debug_str = alloc::format!("{:?}", events);
+    assert!(debug_str.contains("admin_removed"));
+}
+
+#[test]
+fn test_get_admin_count_returns_correct_value() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let contract_id = env.register(PriceOracle, ());
+    let client = PriceOracleClient::new(&env, &contract_id);
+    let admin1 = <soroban_sdk::Address as soroban_sdk::testutils::Address>::generate(&env);
+    let admin2 = <soroban_sdk::Address as soroban_sdk::testutils::Address>::generate(&env);
+
+    // Initially 1 admin
+    client.init_admin(&admin1);
+    assert_eq!(client.get_admin_count(), 1);
+
+    // Add second admin
+    env.as_contract(&contract_id, || {
+        crate::auth::_add_authorized(&env, &admin2);
+    });
+    assert_eq!(client.get_admin_count(), 2);
+}
+
+#[test]
+fn test_full_multi_sig_workflow() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let contract_id = env.register(PriceOracle, ());
+    let client = PriceOracleClient::new(&env, &contract_id);
+    
+    // Start with 2 admins
+    let admin1 = <soroban_sdk::Address as soroban_sdk::testutils::Address>::generate(&env);
+    let admin2 = <soroban_sdk::Address as soroban_sdk::testutils::Address>::generate(&env);
+    let admin3 = <soroban_sdk::Address as soroban_sdk::testutils::Address>::generate(&env);
+
+    client.init_admin(&admin1);
+    env.as_contract(&contract_id, || {
+        crate::auth::_add_authorized(&env, &admin2);
+    });
+
+    // Step 1: Register third admin
+    client.register_admin(&admin1, &admin2, &admin3);
+    assert_eq!(client.get_admin_count(), 3);
+
+    // Step 2: Toggle pause with admin1 and admin3
+    let paused = client.toggle_pause(&admin1, &admin3);
+    assert_eq!(paused, Ok(true));
+
+    // Step 3: Remove admin2 with admin1 and admin3
+    client.remove_admin(&admin1, &admin3, &admin2);
+    assert_eq!(client.get_admin_count(), 2);
+    assert!(!client.is_admin(&admin2));
+
+    // Step 4: Toggle unpause with remaining admins
+    let paused = client.toggle_pause(&admin1, &admin3);
+    assert_eq!(paused, Ok(false));
+}


### PR DESCRIPTION
# closes #129 
Goal:
Prevent a single compromised Admin key from shutting down the network.