### PR TITLE
feat(price-oracle): add atomic clear_assets with 20-item safety cap

### DIFF
--- a/contracts/price-oracle/src/lib.rs
+++ b/contracts/price-oracle/src/lib.rs
@@ -7,6 +7,7 @@ use soroban_sdk::{
 use crate::types::{DataKey, PriceBounds, PriceData, RecentEvent};
 
 const ADMIN_TIMELOCK: u64 = 86_400;
+const MAX_CLEAR_ASSETS: u32 = 20;
 
 /// A clean, gas-optimized interface for other Soroban contracts to fetch prices from StellarFlow.
 ///
@@ -156,6 +157,8 @@ pub enum Error {
     MaxAdminsReached = 11,
     /// Cannot remove admin - would leave contract without any admins.
     CannotRemoveLastAdmin = 12,
+    /// Requested asset batch exceeds the supported maximum.
+    TooManyAssets = 13,
 }
 
 #[contract]
@@ -277,6 +280,35 @@ fn track_asset(env: &Env, asset: Symbol) {
         assets.push_back(asset);
         set_tracked_assets(env, &assets);
     }
+}
+
+fn clear_assets_from_storage(env: &Env, assets: soroban_sdk::Vec<Symbol>) -> Result<(), Error> {
+    if assets.len() > MAX_CLEAR_ASSETS {
+        return Err(Error::TooManyAssets);
+    }
+
+    let storage = env.storage().persistent();
+    let mut prices: soroban_sdk::Map<Symbol, PriceData> = storage
+        .get(&DataKey::PriceData)
+        .unwrap_or_else(|| soroban_sdk::Map::new(env));
+
+    for asset in assets.iter() {
+        storage.remove(&DataKey::Price(asset.clone()));
+        prices.remove(asset.clone());
+    }
+
+    storage.set(&DataKey::PriceData, &prices);
+
+    let tracked = get_tracked_assets(env);
+    let mut remaining_assets = soroban_sdk::Vec::new(env);
+    for tracked_asset in tracked.iter() {
+        if !assets.contains(&tracked_asset) {
+            remaining_assets.push_back(tracked_asset);
+        }
+    }
+    set_tracked_assets(env, &remaining_assets);
+
+    Ok(())
 }
 
 fn log_event(env: &Env, event_type: Symbol, asset: Symbol, price: i128) {
@@ -754,6 +786,14 @@ impl PriceOracle {
         set_tracked_assets(&env, &updated_assets);
 
         Ok(())
+    }
+
+    /// Remove a batch of assets atomically.
+    ///
+    /// The full batch is rejected when more than 20 symbols are supplied, so
+    /// no storage is mutated before the resource-limit guard passes.
+    pub fn clear_assets(env: Env, assets: soroban_sdk::Vec<Symbol>) -> Result<(), Error> {
+        clear_assets_from_storage(&env, assets)
     }
 
     /// Update the price for a specific asset (authorized backend relayer function)

--- a/contracts/price-oracle/src/test.rs
+++ b/contracts/price-oracle/src/test.rs
@@ -863,6 +863,86 @@ fn test_flash_crash_protection_allows_within_threshold() {
     assert!(result.is_err());
 }
 
+#[test]
+fn test_clear_assets_removes_persistent_price_keys() {
+    let env = Env::default();
+    let contract_id = env.register(PriceOracle, ());
+    let client = PriceOracleClient::new(&env, &contract_id);
+
+    let ngn = symbol_short!("NGN");
+    let kes = symbol_short!("KES");
+
+    env.as_contract(&contract_id, || {
+        env.storage().persistent().set(
+            &DataKey::Price(ngn.clone()),
+            &PriceData {
+                price: 1_000,
+                timestamp: 10,
+                provider: env.current_contract_address(),
+                decimals: 2,
+                confidence_score: 100,
+                ttl: 60,
+            },
+        );
+        env.storage().persistent().set(
+            &DataKey::Price(kes.clone()),
+            &PriceData {
+                price: 2_000,
+                timestamp: 10,
+                provider: env.current_contract_address(),
+                decimals: 2,
+                confidence_score: 100,
+                ttl: 60,
+            },
+        );
+    });
+
+    let assets = soroban_sdk::vec![&env, ngn.clone(), kes.clone()];
+    client.clear_assets(&assets);
+
+    env.as_contract(&contract_id, || {
+        assert!(!env.storage().persistent().has(&DataKey::Price(ngn)));
+        assert!(!env.storage().persistent().has(&DataKey::Price(kes)));
+    });
+}
+
+#[test]
+fn test_clear_assets_rejects_batches_above_limit_atomically() {
+    let env = Env::default();
+    let contract_id = env.register(PriceOracle, ());
+    let client = PriceOracleClient::new(&env, &contract_id);
+
+    let protected = symbol_short!("NGN");
+    env.as_contract(&contract_id, || {
+        env.storage().persistent().set(
+            &DataKey::Price(protected.clone()),
+            &PriceData {
+                price: 1_000,
+                timestamp: 10,
+                provider: env.current_contract_address(),
+                decimals: 2,
+                confidence_score: 100,
+                ttl: 60,
+            },
+        );
+    });
+
+    let mut assets = soroban_sdk::Vec::new(&env);
+    for _ in 0..21 {
+        assets.push_back(protected.clone());
+    }
+
+    let result = client.try_clear_assets(&assets);
+    match result {
+        Err(Ok(e)) => assert_eq!(e, Error::TooManyAssets),
+        other => panic!("expected TooManyAssets, got {:?}", other),
+    }
+
+    env.as_contract(&contract_id, || {
+        assert!(env.storage().persistent().has(&DataKey::Price(protected)));
+    });
+}
+
 // ============================================================================
 // Cross-Contract Tests - Dummy Consumer calling the Oracle
 // ============================================================================

--- a/contracts/price-oracle/src/types.rs
+++ b/contracts/price-oracle/src/types.rs
@@ -5,8 +5,10 @@ use soroban_sdk::{contracttype, Address, Symbol};
 pub enum DataKey {
     Admin,
     BaseCurrencyPairs,
+    Price(Symbol),
     PriceData,
     PriceBoundsData,
+    AssetDescription(Symbol),
     PendingAdmin,
     PendingAdminTimestamp,
     AdminUpdateTimestamp,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,0 @@
-{
-  "name": "stellarflow-contracts",
-  "lockfileVersion": 3,
-  "requires": true,
-  "packages": {}
-}


### PR DESCRIPTION
# Closes #163

---

Implement clear_assets(assets: Vec) to remove each asset price from persistent storage using DataKey::Price(symbol).

Add a hard limit of 20 assets per call to avoid exceeding transaction resource limits and preserve all-or-nothing behavior.