### PR TITLE
feat: add get_oracle_health function for Admin Dashboard

### DIFF
--- a/contracts/price-oracle/src/auth.rs
+++ b/contracts/price-oracle/src/auth.rs
@@ -10,6 +10,7 @@ pub enum DataKey {
     Provider(Address),
     ProviderWeight(Address),
     IsPaused,
+    ActiveRelayers,
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -112,6 +113,7 @@ pub fn _add_provider(env: &Env, provider: &Address) {
     env.storage()
         .instance()
         .set(&DataKey::Provider(provider.clone()), &true);
+    _add_to_active_relayers(env, provider);
 }
 
 /// Remove a provider from the whitelist.
@@ -119,6 +121,7 @@ pub fn _remove_provider(env: &Env, provider: &Address) {
     env.storage()
         .instance()
         .remove(&DataKey::Provider(provider.clone()));
+    _remove_from_active_relayers(env, provider);
 }
 
 /// Returns `true` if the address is a whitelisted provider.
@@ -147,6 +150,35 @@ pub fn _get_provider_weight(env: &Env, provider: &Address) -> u32 {
         .instance()
         .get::<DataKey, u32>(&DataKey::ProviderWeight(provider.clone()))
         .unwrap_or(0)
+}
+
+/// Get the list of all active relayers (whitelisted providers).
+pub fn _get_active_relayers(env: &Env) -> Vec<Address> {
+    env.storage()
+        .instance()
+        .get(&DataKey::ActiveRelayers)
+        .unwrap_or_else(|| Vec::new(env))
+}
+
+/// Add a relayer to the active relayers list.
+fn _add_to_active_relayers(env: &Env, provider: &Address) {
+    let mut relayers = _get_active_relayers(env);
+    if !relayers.iter().any(|r| r == *provider) {
+        relayers.push_back(provider.clone());
+        env.storage().instance().set(&DataKey::ActiveRelayers, &relayers);
+    }
+}
+
+/// Remove a relayer from the active relayers list.
+fn _remove_from_active_relayers(env: &Env, provider: &Address) {
+    let relayers = _get_active_relayers(env);
+    let mut filtered = Vec::new(env);
+    for relayer in relayers.iter() {
+        if relayer != *provider {
+            filtered.push_back(relayer);
+        }
+    }
+    env.storage().instance().set(&DataKey::ActiveRelayers, &filtered);
 }
 
 // ─────────────────────────────────────────────────────────────────────────────

--- a/contracts/price-oracle/src/lib.rs
+++ b/contracts/price-oracle/src/lib.rs
@@ -130,6 +130,12 @@ pub trait StellarFlowTrait {
 
     /// Get the total number of registered admins.
     fn get_admin_count(env: Env) -> u32;
+
+    /// Get the health status of the oracle for the Admin Dashboard.
+    ///
+    /// Returns aggregated data from multiple storage keys in a single call.
+    /// This is a read-only function that provides a snapshot of the oracle's current state.
+    fn get_oracle_health(env: Env) -> crate::types::OracleHealth;
 }
 
 #[contractclient(name = "TokenContractClient")]
@@ -1389,6 +1395,24 @@ impl PriceOracle {
     pub fn get_relayer_count(env: Env, asset: Symbol) -> u32 {
         let buffer = get_price_buffer(&env, asset);
         buffer.entries.len()
+    }
+
+    /// Get the health status of the oracle for the Admin Dashboard.
+    ///
+    /// This is a read-only function that aggregates data from 4 different storage keys
+    /// into one single return object for efficient dashboard queries.
+    pub fn get_oracle_health(env: Env) -> crate::types::OracleHealth {
+        let active_relayers = crate::auth::_get_active_relayers(&env).len();
+        let paused = crate::auth::_is_paused(&env);
+        let total_assets = get_tracked_assets(&env).len();
+        let last_ledger = env.ledger().sequence();
+
+        crate::types::OracleHealth {
+            active_relayers,
+            paused,
+            total_assets,
+            last_ledger,
+        }
     }
 }
 

--- a/contracts/price-oracle/src/types.rs
+++ b/contracts/price-oracle/src/types.rs
@@ -16,12 +16,19 @@ pub enum DataKey {
     AdminUpdateTimestamp,
     RecentEvents,
     Initialized,
-    AssetDescription(Symbol),
     /// Verified price bucket: written only by whitelisted providers / admins.
     /// Internal math and `get_price` default to this bucket.
     VerifiedPrice(Symbol),
     /// Community price bucket: written by any caller; never used in internal math.
     CommunityPrice(Symbol),
+    /// Reentrancy lock for set_price function.
+    IsLocked,
+    /// Query fee amount for get_price calls.
+    QueryFee,
+    /// List of all active relayer addresses.
+    ActiveRelayers,
+    /// Destroyed flag to mark contract as permanently unusable.
+    Destroyed,
 }
 
 /// Canonical storage format for a price entry.
@@ -110,4 +117,18 @@ pub struct PriceBuffer {
     pub decimals: u32,
     /// Time-to-live in seconds for this buffer.
     pub ttl: u64,
+}
+
+/// Health status of the oracle for the Admin Dashboard.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct OracleHealth {
+    /// Number of active relayers (whitelisted providers).
+    pub active_relayers: u32,
+    /// Whether the contract is currently paused.
+    pub paused: bool,
+    /// Total number of tracked assets.
+    pub total_assets: u32,
+    /// Current ledger sequence number.
+    pub last_ledger: u32,
 }


### PR DESCRIPTION
# Closes #161

- Add OracleHealth struct with active_relayers, paused, total_assets, last_ledger
- Implement get_oracle_health as pub read_only function
- Track active relayers list in auth module
- Aggregate data from 4 storage keys into single return object