### PR TITLE
feat(price-oracle): variable decimal precision normalized to 9dp (#159)

### DIFF
--- a/contracts/price-oracle/src/lib.rs
+++ b/contracts/price-oracle/src/lib.rs
@@ -4,8 +4,7 @@ use soroban_sdk::{
     contract, contractclient, contracterror, contractimpl, panic_with_error, Address, Env, Symbol, String, token,
 };
 
-use crate::types::{DataKey, PriceBounds, PriceData, PriceDataWithStatus, PriceEntryWithStatus, RecentEvent};
-use crate::types::{DataKey, PriceBounds, PriceBuffer, PriceBufferEntry, PriceData, RecentEvent};
+use crate::types::{AssetMeta, DataKey, PriceBounds, PriceBuffer, PriceBufferEntry, PriceData, PriceDataWithStatus, PriceEntryWithStatus, RecentEvent};
 
 const ADMIN_TIMELOCK: u64 = 86_400;
 const MAX_CLEAR_ASSETS: u32 = 20;
@@ -482,6 +481,23 @@ fn enforce_price_floor(env: &Env, asset: &Symbol, price: i128) -> Result<(), Err
     Ok(())
 }
 
+/// Normalize a raw price to 9 fixed-point decimals using the asset's stored
+/// `quote_decimals` metadata.
+///
+/// If no metadata has been registered for the asset the raw price is returned
+/// unchanged (backward-compatible behaviour for assets added before this feature).
+fn normalize_price(env: &Env, asset: &Symbol, raw_price: i128) -> i128 {
+    let meta: Option<crate::types::AssetMeta> = env
+        .storage()
+        .persistent()
+        .get(&DataKey::AssetMeta(asset.clone()));
+
+    match meta {
+        Some(m) => crate::math::normalize_to_nine(raw_price, m.quote_decimals),
+        None => raw_price,
+    }
+}
+
 #[contractimpl]
 impl PriceOracle {
     /// Initialize the contract with admin and base currency pairs.
@@ -534,6 +550,7 @@ impl PriceOracle {
     }
 
     /// Add a new asset to the tracked asset list.
+    /// Add a new asset to the tracked asset list.
     ///
     /// The new asset is added to the internal asset list and initialized with a zero-price placeholder
     /// in the `VerifiedPrice` bucket.
@@ -563,6 +580,40 @@ impl PriceOracle {
         log_event(&env, Symbol::new(&env, "asset_added"), asset, 0);
 
         Ok(())
+    }
+
+    /// Register the native decimal precision for an asset pair.
+    ///
+    /// Stores `base_decimals` and `quote_decimals` in persistent storage so that
+    /// all subsequent price submissions for this asset are automatically normalized
+    /// to 9 fixed-point decimals on entry.
+    ///
+    /// Only the admin can call this. Should be called once per asset after `add_asset`.
+    pub fn set_asset_decimals(
+        env: Env,
+        admin: Address,
+        asset: Symbol,
+        base_decimals: u32,
+        quote_decimals: u32,
+    ) {
+        _require_not_destroyed(&env);
+        admin.require_auth();
+        crate::auth::_require_authorized(&env, &admin);
+
+        env.storage().persistent().set(
+            &DataKey::AssetMeta(asset),
+            &AssetMeta { base_decimals, quote_decimals },
+        );
+    }
+
+    /// Get the decimal metadata for an asset.
+    ///
+    /// Returns the `AssetMeta` containing `base_decimals` and `quote_decimals`
+    /// registered via `set_asset_decimals`.
+    pub fn get_asset_meta(env: Env, asset: Symbol) -> Option<AssetMeta> {
+        env.storage()
+            .persistent()
+            .get(&DataKey::AssetMeta(asset))
     }
 
     /// Return the current admin addresses.
@@ -838,7 +889,11 @@ impl PriceOracle {
             if !is_valid(val) {
                 return Err(Error::InvalidPrice);
             }
-            if let Err(err) = enforce_price_floor(&env, &asset, val) {
+
+            // Normalize the raw price to 9 fixed-point decimals on entry.
+            let normalized = normalize_price(&env, &asset, val);
+
+            if let Err(err) = enforce_price_floor(&env, &asset, normalized) {
                 return Err(err);
             }
 
@@ -852,21 +907,22 @@ impl PriceOracle {
             let now = env.ledger().timestamp();
 
             if let Some(mut current) = existing {
-                if current.price == val {
+                if current.price == normalized {
                     // Price unchanged — only refresh the timestamp (zero-write optimisation).
                     current.timestamp = now;
                     storage.set(&key, &current);
-                    env.events().publish_event(&PriceUpdatedEvent { asset: asset.clone(), price: val });
-                    log_event(&env, Symbol::new(&env, "price_updated"), asset, val);
+                    env.events().publish_event(&PriceUpdatedEvent { asset: asset.clone(), price: normalized });
+                    log_event(&env, Symbol::new(&env, "price_updated"), asset, normalized);
                     return Ok(());
                 }
             }
 
             let price_data = PriceData {
-                price: val,
+                price: normalized,
                 timestamp: now,
                 provider: env.current_contract_address(),
-                decimals,
+                // All stored prices are 9-decimal normalized.
+                decimals: 9,
                 confidence_score: 100,
                 ttl,
             };
@@ -875,12 +931,12 @@ impl PriceOracle {
 
             if is_new_asset {
                 env.events().publish_event(&AssetAddedEvent { symbol: asset.clone() });
-                log_event(&env, Symbol::new(&env, "asset_added"), asset, val);
+                log_event(&env, Symbol::new(&env, "asset_added"), asset, normalized);
             } else {
-                log_event(&env, Symbol::new(&env, "price_updated"), asset.clone(), val);
+                log_event(&env, Symbol::new(&env, "price_updated"), asset.clone(), normalized);
                 env.events().publish_event(&PriceUpdatedEvent {
                     asset: asset.clone(),
-                    price: val,
+                    price: normalized,
                 });
             }
             
@@ -895,27 +951,6 @@ impl PriceOracle {
             panic_with_error!(&env, err);
         }
     }
-            timestamp: now,
-            provider: env.current_contract_address(),
-            decimals,
-            confidence_score: 100,
-            ttl,
-        };
-
-        storage.set(&key, &price_data);
-
-        if is_new_asset {
-            env.events().publish_event(&AssetAddedEvent { symbol: asset.clone() });
-            log_event(&env, Symbol::new(&env, "asset_added"), asset, val);
-        } else {
-            log_event(&env, Symbol::new(&env, "price_updated"), asset.clone(), val);
-            env.events().publish_event(&PriceUpdatedEvent {
-                asset: asset.clone(),
-                price: val,
-            });
-        }
-    }
-
     /// Submit a community (unverified) price for an asset.
     ///
     /// Any caller may submit a price here; it is stored in the `CommunityPrice`
@@ -939,12 +974,16 @@ impl PriceOracle {
             return Err(Error::InvalidPrice);
         }
 
+        // Normalize the raw price to 9 fixed-point decimals on entry.
+        let normalized = normalize_price(&env, &asset, price);
+
         let now = env.ledger().timestamp();
         let price_data = PriceData {
-            price,
+            price: normalized,
             timestamp: now,
             provider: source,
-            decimals,
+            // All stored prices are 9-decimal normalized.
+            decimals: 9,
             confidence_score: 0,
             ttl,
         };
@@ -953,7 +992,7 @@ impl PriceOracle {
             .temporary()
             .set(&DataKey::CommunityPrice(asset.clone()), &price_data);
 
-        log_event(&env, Symbol::new(&env, "community_price"), asset, price);
+        log_event(&env, Symbol::new(&env, "community_price"), asset, normalized);
 
         Ok(())
     }
@@ -1048,6 +1087,9 @@ impl PriceOracle {
             return Err(Error::NotAuthorized);
         }
 
+        // Normalize the raw price to 9 fixed-point decimals on entry.
+        let normalized = normalize_price(&env, &asset, price);
+
         // Get the current buffer for this asset
         let mut buffer = get_price_buffer(&env, asset.clone());
         
@@ -1066,7 +1108,7 @@ impl PriceOracle {
             .unwrap_or(0);
 
         if old_price > 0 {
-            if let Some(pct_change_bps) = calculate_percentage_difference_bps(old_price, price) {
+            if let Some(pct_change_bps) = calculate_percentage_difference_bps(old_price, normalized) {
                 if pct_change_bps > MAX_PERCENT_CHANGE_BPS {
                     return Err(Error::FlashCrashDetected);
                 }
@@ -1074,19 +1116,19 @@ impl PriceOracle {
         }
 
         if old_price != 0 {
-            let delta = (price - old_price).unsigned_abs();
+            let delta = (normalized - old_price).unsigned_abs();
             if delta > 50 {
                 env.events().publish_event(&PriceAnomalyEvent {
                     asset: asset.clone(),
                     previous_price: old_price,
-                    attempted_price: price,
+                    attempted_price: normalized,
                     delta,
                 });
                 // Still allow the submission even if anomaly detected
             }
         }
 
-        enforce_price_floor(&env, &asset, price)?;
+        enforce_price_floor(&env, &asset, normalized)?;
 
         let storage = env.storage().persistent();
         let bounds_map: soroban_sdk::Map<Symbol, PriceBounds> = storage
@@ -1094,26 +1136,27 @@ impl PriceOracle {
             .unwrap_or_else(|| soroban_sdk::Map::new(&env));
         
         if let Some(bounds) = bounds_map.get(asset.clone()) {
-            if price < bounds.min_price || price > bounds.max_price {
+            if normalized < bounds.min_price || normalized > bounds.max_price {
                 return Err(Error::PriceOutOfBounds);
             }
         }
 
-        // Add the new price entry to the buffer
+        // Add the normalized price entry to the buffer
         let entry = PriceBufferEntry {
-            price,
+            price: normalized,
             provider: source.clone(),
             timestamp: env.ledger().timestamp(),
         };
         buffer.entries.push_back(entry);
-        buffer.decimals = decimals;
+        // Buffer decimals are always 9 after normalization.
+        buffer.decimals = 9;
         buffer.ttl = ttl;
 
         // Save the updated buffer
         set_price_buffer(&env, asset.clone(), &buffer);
 
         // Calculate the new median and store it as the canonical price
-        let median_price = calculate_median_from_buffer(&env, &buffer).unwrap_or(price);
+        let median_price = calculate_median_from_buffer(&env, &buffer).unwrap_or(normalized);
         
         // Also update the legacy PriceData for backward compatibility
         let mut prices: soroban_sdk::Map<Symbol, PriceData> = storage
@@ -1124,15 +1167,16 @@ impl PriceOracle {
             price: median_price,
             timestamp: env.ledger().timestamp(),
             provider: source,
-            decimals,
+            // All stored prices are 9-decimal normalized.
+            decimals: 9,
             confidence_score,
             ttl,
         };
 
         storage.set(&key, &price_data);
 
-        env.events().publish_event(&PriceUpdatedEvent { asset: asset.clone(), price });
-        log_event(&env, Symbol::new(&env, "price_updated"), asset, price);
+        env.events().publish_event(&PriceUpdatedEvent { asset: asset.clone(), price: normalized });
+        log_event(&env, Symbol::new(&env, "price_updated"), asset, normalized);
 
         Ok(())
     }

--- a/contracts/price-oracle/src/math.rs
+++ b/contracts/price-oracle/src/math.rs
@@ -115,6 +115,36 @@ pub fn normalize_to_seven(value: i128, input_decimals: u32) -> i128 {
     }
 }
 
+/// Normalize a raw price to 9 fixed-point decimals regardless of the asset's
+/// native decimal precision.
+///
+/// All internal math uses 9-decimal fixed-point so that developers never need
+/// to write different logic for different assets.
+///
+/// Formula: `price * 10^(9 - native_decimals)`
+///
+/// # Examples
+/// ```text
+/// normalize_to_nine(1_000_000_0, 7)  => 1_000_000_000  (XLM, 7 dec → 9 dec)
+/// normalize_to_nine(100,         2)  => 10_000_000_000  (NGN, 2 dec → 9 dec)
+/// normalize_to_nine(1_000_000_000, 9) => 1_000_000_000  (already 9 dec, no-op)
+/// normalize_to_nine(1_000_000_000_00, 11) => 1_000_000_000 (scale down)
+/// ```
+pub fn normalize_to_nine(value: i128, native_decimals: u32) -> i128 {
+    const TARGET: u32 = 9;
+    if native_decimals < TARGET {
+        let diff = TARGET - native_decimals;
+        let multiplier = 10_i128.checked_pow(diff).expect("Overflow on multiplier pow");
+        value.checked_mul(multiplier).expect("Overflow on multiplication")
+    } else if native_decimals > TARGET {
+        let diff = native_decimals - TARGET;
+        let divisor = 10_i128.checked_pow(diff).expect("Overflow on divisor pow");
+        value.checked_div(divisor).expect("Overflow on division")
+    } else {
+        value
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -190,5 +220,37 @@ mod tests {
     #[test]
     fn test_normalize_to_seven_no_scale() {
         assert_eq!(normalize_to_seven(1234567, 7), 1234567);
+    }
+
+    // --- normalize_to_nine tests ---------------------------------------------
+
+    #[test]
+    fn test_normalize_to_nine_scale_up_from_7() {
+        // XLM has 7 decimals: multiply by 10^2
+        assert_eq!(normalize_to_nine(10_000_000, 7), 1_000_000_000);
+    }
+
+    #[test]
+    fn test_normalize_to_nine_scale_up_from_2() {
+        // NGN has 2 decimals: multiply by 10^7
+        assert_eq!(normalize_to_nine(100, 2), 10_000_000_000);
+    }
+
+    #[test]
+    fn test_normalize_to_nine_no_scale() {
+        // Already 9 decimals — no-op
+        assert_eq!(normalize_to_nine(1_000_000_000, 9), 1_000_000_000);
+    }
+
+    #[test]
+    fn test_normalize_to_nine_scale_down() {
+        // 11 decimals → divide by 10^2
+        assert_eq!(normalize_to_nine(100_000_000_000, 11), 1_000_000_000);
+    }
+
+    #[test]
+    fn test_normalize_to_nine_zero_decimals() {
+        // 0 native decimals → multiply by 10^9
+        assert_eq!(normalize_to_nine(1, 0), 1_000_000_000);
     }
 }

--- a/contracts/price-oracle/src/types.rs
+++ b/contracts/price-oracle/src/types.rs
@@ -25,6 +25,21 @@ pub enum DataKey {
     QueryFee,
     /// Destroyed flag to mark contract as permanently unusable.
     Destroyed,
+    /// Asset decimal metadata (base_decimals, quote_decimals).
+    AssetMeta(Symbol),
+}
+
+/// Decimal metadata for an asset pair.
+///
+/// Stores the native decimal precision of the base and quote assets so the
+/// contract can normalize all prices to 9 fixed-point decimals on entry.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct AssetMeta {
+    /// Native decimal precision of the base asset (e.g. 7 for XLM).
+    pub base_decimals: u32,
+    /// Native decimal precision of the quote asset (e.g. 2 for NGN).
+    pub quote_decimals: u32,
 }
 
 /// Canonical storage format for a price entry.


### PR DESCRIPTION
# Closes #159

Standardizes all internal math to 9 fixed-point decimals regardless of an asset's native decimal precision.