### PR TITLE
Add configurable max deviation parameter to price oracle and enforce it in update_price

### DIFF
--- a/contracts/price-oracle/src/lib.rs
+++ b/contracts/price-oracle/src/lib.rs
@@ -228,8 +228,8 @@ pub trait TokenContractTrait {
     fn transfer(env: Env, from: Address, to: Address, amount: i128);
 }
 
-/// Maximum allowed percentage change between price updates (10% = 1000 basis points).
-/// Any price update exceeding this threshold will be rejected to prevent flash crashes.
+/// Default maximum allowed percentage change between price updates (10% = 1000 basis points).
+/// This value is used when no configurable max deviation percentage has been set.
 const MAX_PERCENT_CHANGE_BPS: i128 = 1_000;
 
 /// Percentage move threshold (5% = 500 basis points) above which a "cross_call"
@@ -1249,9 +1249,10 @@ impl PriceOracle {
             .map(|pd| pd.price)
             .unwrap_or(0);
 
+        let max_deviation_bps = Self::get_max_deviation_percentage(env.clone());
         if old_price > 0 {
             if let Some(pct_change_bps) = calculate_percentage_difference_bps(old_price, normalized) {
-                if pct_change_bps > MAX_PERCENT_CHANGE_BPS {
+                if pct_change_bps > max_deviation_bps {
                     return Err(Error::FlashCrashDetected);
                 }
             }
@@ -1408,6 +1409,34 @@ impl PriceOracle {
             .get(&DataKey::PriceBoundsData)
             .unwrap_or_else(|| soroban_sdk::Map::new(&env));
         bounds_map.get(asset)
+    }
+
+    /// Set the maximum allowed price deviation percentage (in basis points).
+    /// This value is applied in `update_price` to reject single-ledger flash crash updates.
+    pub fn set_max_deviation_percentage(
+        env: Env,
+        admin: Address,
+        max_deviation_bps: i128,
+    ) {
+        _require_not_destroyed(&env);
+        crate::auth::_require_not_frozen(&env);
+        admin.require_auth();
+        crate::auth::_require_authorized(&env, &admin);
+
+        assert!(max_deviation_bps > 0, "max_deviation_bps must be positive");
+        assert!(max_deviation_bps <= 10_000, "max_deviation_bps must be <= 10000");
+
+        env.storage()
+            .persistent()
+            .set(&DataKey::MaxPriceDeviationBps, &max_deviation_bps);
+    }
+
+    /// Get the configured maximum allowed price deviation, or default to 10%.
+    pub fn get_max_deviation_percentage(env: Env) -> i128 {
+        env.storage()
+            .persistent()
+            .get(&DataKey::MaxPriceDeviationBps)
+            .unwrap_or(MAX_PERCENT_CHANGE_BPS)
     }
 
     /// Get the current ledger sequence number.

--- a/contracts/price-oracle/src/test.rs
+++ b/contracts/price-oracle/src/test.rs
@@ -235,6 +235,38 @@ fn test_update_price_rejects_flash_crash() {
 }
 
 #[test]
+fn test_set_and_get_max_deviation_percentage() {
+    let (env, contract_id, client) = setup();
+    let admin = Address::generate(&env);
+
+    set_admin(&env, &contract_id, &admin);
+    client.set_max_deviation_percentage(&admin, &500_i128);
+
+    let max_deviation = client.get_max_deviation_percentage();
+    assert_eq!(max_deviation, 500_i128);
+}
+
+#[test]
+fn test_update_price_rejects_configured_max_deviation() {
+    let (env, contract_id, client) = setup();
+    let admin = Address::generate(&env);
+    let provider = Address::generate(&env);
+    let asset = symbol_short!("NGN");
+
+    set_admin(&env, &contract_id, &admin);
+    add_provider(&env, &contract_id, &provider);
+    client.add_asset(&admin, &asset);
+    client.set_max_deviation_percentage(&admin, &500_i128);
+    client.set_price(&asset, &1_000_i128, &2u32, &3_600u64);
+
+    let result = client.try_update_price(&provider, &asset, &1_100_i128, &2u32, &100u32, &3_600u64);
+    match result {
+        Err(Ok(err)) => assert_eq!(err, Error::FlashCrashDetected),
+        other => panic!("expected FlashCrashDetected, got {:?}", other),
+    }
+}
+
+#[test]
 fn test_set_and_get_price_bounds() {
     let (env, contract_id, client) = setup();
     let admin = Address::generate(&env);

--- a/contracts/price-oracle/src/types.rs
+++ b/contracts/price-oracle/src/types.rs
@@ -10,6 +10,8 @@ pub enum DataKey {
     PriceData,
     PriceBuffer,
     PriceBoundsData,
+    /// Configurable global maximum allowed price deviation in basis points.
+    MaxPriceDeviationBps,
     IsLocked,
     PriceFloorData,
     AssetDescription(Symbol),


### PR DESCRIPTION
Close #184 

### Summary
Implemented a configurable `max_deviation_percentage` parameter for the StellarFlow price oracle and enforced it during `update_price()` to reject single-ledger price updates that exceed the configured threshold.

### Changes
- Added `DataKey::MaxPriceDeviationBps` to store the configured deviation limit.
- Added admin API:
  - `set_max_deviation_percentage(env, admin, max_deviation_bps)`
  - `get_max_deviation_percentage(env)`
- Updated `update_price()` to use the configured max deviation threshold and reject updates that exceed it.
- Preserved default behavior at `10%` (1000 basis points) when not configured.
- Added regression tests covering:
  - setting/getting the max deviation parameter
  - rejecting updates that exceed the configured threshold

### Testing
- Recommended command:
  - `cd contracts/price-oracle && cargo test`