### PR TITLE
fix: Standardized the events emitted by backend tools

### DIFF
--- a/contracts/price-oracle/src/lib.rs
+++ b/contracts/price-oracle/src/lib.rs
@@ -289,6 +289,8 @@ pub struct PriceOracle;
 pub struct PriceUpdatedEvent {
     pub asset: Symbol,
     pub price: i128,
+    pub timestamp: u64,
+    pub relayer: Address,
 }
 
 #[soroban_sdk::contractevent]
@@ -1042,7 +1044,15 @@ impl PriceOracle {
                     current.timestamp = now;
                     storage.set(&key, &current);
                     update_twap(&env, asset.clone(), val, now);
-                    env.events().publish_event(&PriceUpdatedEvent { asset: asset.clone(), price: val });
+                    env.events().publish(
+                        (Symbol::new(&env, "price_updated"), asset.clone()),
+                        PriceUpdatedEvent {
+                            asset: asset.clone(),
+                            price: val,
+                            timestamp: now,
+                            relayer: env.current_contract_address(),
+                        },
+                    );
                     log_event(&env, Symbol::new(&env, "price_updated"), asset, val);
                     return Ok(());
                 }
@@ -1066,10 +1076,15 @@ impl PriceOracle {
                 log_event(&env, Symbol::new(&env, "asset_added"), asset.clone(), normalized);
             } else {
                 log_event(&env, Symbol::new(&env, "price_updated"), asset.clone(), normalized);
-                env.events().publish_event(&PriceUpdatedEvent {
-                    asset: asset.clone(),
-                    price: normalized,
-                });
+                env.events().publish(
+                    (Symbol::new(&env, "price_updated"), asset.clone()),
+                    PriceUpdatedEvent {
+                        asset: asset.clone(),
+                        price: normalized,
+                        timestamp: now,
+                        relayer: env.current_contract_address(),
+                    },
+                );
             }
 
             // Notify subscribers of the price update
@@ -1353,7 +1368,16 @@ impl PriceOracle {
         storage.set(&key, &price_data);
         update_twap(&env, asset.clone(), median_price, env.ledger().timestamp());
 
-        env.events().publish_event(&PriceUpdatedEvent { asset: asset.clone(), price: normalized });
+        let now = env.ledger().timestamp();
+        env.events().publish(
+            (Symbol::new(&env, "price_updated"), asset.clone()),
+            PriceUpdatedEvent {
+                asset: asset.clone(),
+                price: median_price,
+                timestamp: now,
+                relayer: source.clone(),
+            },
+        );
         log_event(&env, Symbol::new(&env, "price_updated"), asset.clone(), normalized);
 
         // Notify all subscribed contracts of the price update


### PR DESCRIPTION
Closes #196

## 📡 Feat: Standardized Event Emission for Off-Chain Indexing

Standardizes oracle price events so backend indexing tools (Mercury, Horizon) can perfectly mirror on-chain price history.

### Changes

**`PriceUpdatedEvent` Schema**
- Added `timestamp` and `relayer` (`Address`) fields to match the required `{ asset, price, timestamp, relayer }` schema

**Enhanced Indexing**
- Switched from `publish_event` to `env.events().publish()` with multiple topics: `("price_updated", asset_symbol)`
- Enables backend tools to query price history per asset without scanning all oracle events

**Data Integrity**
- Event now reports `median_price` — the exact value committed to storage — ensuring off-chain indexes are a perfect mirror of on-chain state

**Relayer Attribution**
- `relayer` field explicitly tracks the update source: specific relayer address for `update_price` calls, contract address for admin `set_price` calls