### PR TITLE
feat: implement batch price update functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@ This repository contains smart contracts for the StellarFlow Network with a time
 - **Admin-Only Operations**: Only contract administrators can propose and execute upgrades
 - **Upgrade Cancellation**: Ability to cancel pending upgrades before execution
 - **Timelock Monitoring**: Functions to check remaining timelock time
+- **Batch Price Updates**: Efficient multi-asset price updates in a single transaction
+- **Fee Optimization**: Reduces submission fees by batching 5+ asset price updates
 
 ## Architecture
 
@@ -24,14 +26,29 @@ This repository contains smart contracts for the StellarFlow Network with a time
    - `admin`: Administrator address with upgrade permissions
    - `value`: Sample storage value for testing
 
+3. **AssetPrice Struct**: Stores individual asset price information
+   - `asset_code`: Symbol representing the asset (e.g., "BTC", "ETH")
+   - `price`: Current price of the asset
+   - `timestamp`: When the price was last updated
+
+4. **PriceUpdate Struct**: Input structure for price updates
+   - `asset_code`: Symbol representing the asset
+   - `price`: New price to set
+
 ### Key Functions
 
+#### Upgrade Management
 - `initialize()`: Sets up the contract with an admin address
 - `propose_upgrade()`: Initiates the 48-hour timelock period
 - `execute_upgrade()`: Executes the upgrade after timelock expires
 - `cancel_upgrade()`: Cancels a pending upgrade
 - `get_pending_upgrade()`: Retrieves pending upgrade information
 - `get_upgrade_timelock_remaining()`: Returns remaining timelock time
+
+#### Price Management
+- `update_prices_batch()`: Updates prices for 5+ assets in a single transaction
+- `get_price()`: Retrieves the current price for a specific asset
+- `get_all_prices()`: Returns all current asset prices
 
 ## Security Features
 
@@ -52,6 +69,7 @@ The contract prevents flash upgrades through:
 
 ## Usage Example
 
+### Upgrade Management
 ```rust
 // Initialize contract
 contract.initialize(&admin_address);
@@ -68,6 +86,43 @@ println!("Time remaining: {} seconds", remaining.unwrap());
 contract.execute_upgrade(&admin_address);
 ```
 
+### Batch Price Updates
+```rust
+// Create price updates for 5+ assets
+let mut price_updates = Vec::new(&env);
+price_updates.push_back(PriceUpdate {
+    asset_code: Symbol::short("BTC"),
+    price: 50000,
+});
+price_updates.push_back(PriceUpdate {
+    asset_code: Symbol::short("ETH"),
+    price: 3000,
+});
+price_updates.push_back(PriceUpdate {
+    asset_code: Symbol::short("USDC"),
+    price: 1000,
+});
+price_updates.push_back(PriceUpdate {
+    asset_code: Symbol::short("USDT"),
+    price: 1000,
+});
+price_updates.push_back(PriceUpdate {
+    asset_code: Symbol::short("XLM"),
+    price: 100,
+});
+
+// Update all prices in a single transaction (saves on fees)
+contract.update_prices_batch(&price_updates, &admin_address);
+
+// Retrieve individual price
+let btc_price = contract.get_price(&Symbol::short("BTC"));
+println!("BTC price: {}", btc_price.unwrap().price);
+
+// Get all prices
+let all_prices = contract.get_all_prices();
+println!("Total assets tracked: {}", all_prices.len());
+```
+
 ## Testing
 
 The contract includes comprehensive tests covering:
@@ -77,6 +132,10 @@ The contract includes comprehensive tests covering:
 - Timelock enforcement and countdown
 - Unauthorized operation prevention
 - Upgrade cancellation
+- Batch price update functionality
+- Minimum asset requirement enforcement (5+ assets)
+- Price timestamp tracking
+- Authorization for price updates
 
 Run tests with:
 
@@ -90,6 +149,9 @@ cargo test
 ✅ **Pending State Storage**: New WASM hash stored in pending state before commitment  
 ✅ **48-Hour Delay**: Enforced delay between proposal and execution  
 ✅ **Flash Upgrade Prevention**: Complete protection against immediate upgrades  
+✅ **Batch Price Updates**: `update_prices_batch(Vec)` function implemented  
+✅ **Multi-Asset Efficiency**: Supports 5+ asset updates in single transaction  
+✅ **Fee Optimization**: Reduces submission fees through batching  
 
 ## Build and Deploy
 

--- a/examples/batch_price_update.rs
+++ b/examples/batch_price_update.rs
@@ -1,0 +1,50 @@
+use soroban_sdk::{Address, Env, Symbol, Vec};
+use stellarflow_contracts::{TimeLockedUpgradeContract, PriceUpdate};
+
+pub fn main() {
+    // This example demonstrates how to use the batch price update functionality
+    // In a real scenario, this would be called by a relayer to update multiple asset prices
+    
+    let env = Env::default();
+    let contract_id = env.register_contract(None, TimeLockedUpgradeContract);
+    let admin = Address::generate(&env);
+    
+    // Initialize the contract (in a real deployment, this would be done once)
+    // TimeLockedUpgradeContract::initialize(env.clone(), admin.clone());
+    
+    // Create a batch of price updates for 5+ assets
+    let mut price_updates = Vec::new(&env);
+    
+    // Add price updates for different assets
+    price_updates.push_back(PriceUpdate {
+        asset_code: Symbol::short("BTC"),
+        price: 50000, // $50,000
+    });
+    
+    price_updates.push_back(PriceUpdate {
+        asset_code: Symbol::short("ETH"),
+        price: 3000, // $3,000
+    });
+    
+    price_updates.push_back(PriceUpdate {
+        asset_code: Symbol::short("USDC"),
+        price: 1000, // $1.00 (scaled by 1000 for precision)
+    });
+    
+    price_updates.push_back(PriceUpdate {
+        asset_code: Symbol::short("USDT"),
+        price: 1000, // $1.00 (scaled by 1000 for precision)
+    });
+    
+    price_updates.push_back(PriceUpdate {
+        asset_code: Symbol::short("XLM"),
+        price: 100, // $0.10 (scaled by 1000 for precision)
+    });
+    
+    // In a real implementation, the relayer would call:
+    // TimeLockedUpgradeContract::update_prices_batch(env.clone(), price_updates, admin);
+    
+    println!("Batch price update example created with {} assets", price_updates.len());
+    println!("This allows relayers to update multiple asset prices in a single transaction,");
+    println!("saving on submission fees compared to individual updates.");
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,8 +1,9 @@
-use soroban_sdk::{contract, contractimpl, contracttype, Address, Env, Bytes, BytesN, Symbol, Vec};
+use soroban_sdk::{contract, contractimpl, contracttype, Address, Env, Bytes, BytesN, Symbol, Vec, Map};
 
 // Contract state keys
 const DATA_KEY: Symbol = Symbol::short("DATA");
 const PENDING_UPGRADE_KEY: Symbol = Symbol::short("PENDING");
+const PRICE_DATA_KEY: Symbol = Symbol::short("PRICES");
 const UPGRADE_DELAY_SECONDS: u64 = 48 * 60 * 60; // 48 hours in seconds
 
 #[contracttype]
@@ -17,6 +18,21 @@ pub struct PendingUpgrade {
 pub struct ContractData {
     pub admin: Address,
     pub value: u64,
+}
+
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct AssetPrice {
+    pub asset_code: Symbol,
+    pub price: u64,
+    pub timestamp: u64,
+}
+
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct PriceUpdate {
+    pub asset_code: Symbol,
+    pub price: u64,
 }
 
 #[contract]
@@ -159,6 +175,64 @@ impl TimeLockedUpgradeContract {
         
         data.value = value;
         env.storage().instance().set(&DATA_KEY, &data);
+    }
+
+    /// Update prices for multiple assets in a single transaction
+    /// This allows relayers to update 5+ assets efficiently, saving on submission fees
+    pub fn update_prices_batch(env: Env, price_updates: Vec<PriceUpdate>, relayer: Address) {
+        let data = Self::get_data(env.clone());
+        
+        // Only admin can update prices
+        if data.admin != relayer {
+            panic!("only admin can update prices");
+        }
+        
+        relayer.require_auth();
+        
+        // Validate that we have at least 5 assets for batch efficiency
+        if price_updates.len() < 5 {
+            panic!("batch update requires at least 5 assets for efficiency");
+        }
+        
+        // Get current price data or create new map
+        let mut price_map: Map<Symbol, AssetPrice> = env.storage()
+            .instance()
+            .get(&PRICE_DATA_KEY)
+            .unwrap_or_else(|| Map::new(&env));
+        
+        let current_time = env.ledger().timestamp();
+        
+        // Update each price in the batch
+        for price_update in price_updates.iter() {
+            let asset_price = AssetPrice {
+                asset_code: price_update.asset_code.clone(),
+                price: price_update.price,
+                timestamp: current_time,
+            };
+            
+            price_map.set(price_update.asset_code.clone(), asset_price);
+        }
+        
+        // Store the updated price map
+        env.storage().instance().set(&PRICE_DATA_KEY, &price_map);
+    }
+
+    /// Get the price for a specific asset
+    pub fn get_price(env: Env, asset_code: Symbol) -> Option<AssetPrice> {
+        let price_map: Map<Symbol, AssetPrice> = env.storage()
+            .instance()
+            .get(&PRICE_DATA_KEY)
+            .unwrap_or_else(|| Map::new(&env));
+        
+        price_map.get(asset_code)
+    }
+
+    /// Get all current prices
+    pub fn get_all_prices(env: Env) -> Map<Symbol, AssetPrice> {
+        env.storage()
+            .instance()
+            .get(&PRICE_DATA_KEY)
+            .unwrap_or_else(|| Map::new(&env))
     }
 }
 

--- a/src/test.rs
+++ b/src/test.rs
@@ -1,5 +1,5 @@
-use soroban_sdk::{Address, BytesN, Env, Symbol};
-use crate::{TimeLockedUpgradeContract, PendingUpgrade, UPGRADE_DELAY_SECONDS};
+use soroban_sdk::{Address, BytesN, Env, Symbol, Vec, Map};
+use crate::{TimeLockedUpgradeContract, PendingUpgrade, UPGRADE_DELAY_SECONDS, AssetPrice, PriceUpdate};
 
 pub struct TimeLockedUpgradeClient<'a> {
     env: &'a Env,
@@ -73,6 +73,30 @@ impl<'a> TimeLockedUpgradeClient<'a> {
             &Symbol::short("set_value"),
             (value, setter),
         );
+    }
+
+    pub fn update_prices_batch(&self, price_updates: &Vec<PriceUpdate>, relayer: &Address) {
+        self.env.invoke_contract(
+            self.contract_id,
+            &Symbol::short("update_prices_batch"),
+            (price_updates, relayer),
+        );
+    }
+
+    pub fn get_price(&self, asset_code: &Symbol) -> Option<AssetPrice> {
+        self.env.invoke_contract(
+            self.contract_id,
+            &Symbol::short("get_price"),
+            (asset_code,),
+        )
+    }
+
+    pub fn get_all_prices(&self) -> Map<Symbol, AssetPrice> {
+        self.env.invoke_contract(
+            self.contract_id,
+            &Symbol::short("get_all_prices"),
+            (),
+        )
     }
 }
 
@@ -252,4 +276,191 @@ fn test_timelock_countdown() {
     // Timelock should be satisfied
     let remaining = client.get_upgrade_timelock_remaining().unwrap();
     assert_eq!(remaining, 0);
+}
+
+#[test]
+fn test_batch_price_update_success() {
+    let env = Env::default();
+    let contract_id = env.register_contract(None, TimeLockedUpgradeContract);
+    let client = TimeLockedUpgradeClient::new(&env, &contract_id);
+    
+    let admin = Address::generate(&env);
+    client.initialize(&admin);
+    
+    // Create price updates for 5+ assets
+    let mut price_updates = Vec::new(&env);
+    
+    // Add 5 different assets with their prices
+    price_updates.push_back(PriceUpdate {
+        asset_code: Symbol::short("BTC"),
+        price: 50000,
+    });
+    price_updates.push_back(PriceUpdate {
+        asset_code: Symbol::short("ETH"),
+        price: 3000,
+    });
+    price_updates.push_back(PriceUpdate {
+        asset_code: Symbol::short("USDC"),
+        price: 1000,
+    });
+    price_updates.push_back(PriceUpdate {
+        asset_code: Symbol::short("USDT"),
+        price: 1000,
+    });
+    price_updates.push_back(PriceUpdate {
+        asset_code: Symbol::short("XLM"),
+        price: 100,
+    });
+    
+    // Update prices in batch
+    client.update_prices_batch(&price_updates, &admin);
+    
+    // Verify all prices were updated
+    let btc_price = client.get_price(&Symbol::short("BTC"));
+    assert!(btc_price.is_some());
+    assert_eq!(btc_price.unwrap().price, 50000);
+    
+    let eth_price = client.get_price(&Symbol::short("ETH"));
+    assert!(eth_price.is_some());
+    assert_eq!(eth_price.unwrap().price, 3000);
+    
+    let all_prices = client.get_all_prices();
+    assert_eq!(all_prices.len(), 5);
+}
+
+#[test]
+fn test_batch_price_update_minimum_assets() {
+    let env = Env::default();
+    let contract_id = env.register_contract(None, TimeLockedUpgradeContract);
+    let client = TimeLockedUpgradeClient::new(&env, &contract_id);
+    
+    let admin = Address::generate(&env);
+    client.initialize(&admin);
+    
+    // Try with only 4 assets (should fail)
+    let mut price_updates = Vec::new(&env);
+    price_updates.push_back(PriceUpdate {
+        asset_code: Symbol::short("BTC"),
+        price: 50000,
+    });
+    price_updates.push_back(PriceUpdate {
+        asset_code: Symbol::short("ETH"),
+        price: 3000,
+    });
+    price_updates.push_back(PriceUpdate {
+        asset_code: Symbol::short("USDC"),
+        price: 1000,
+    });
+    price_updates.push_back(PriceUpdate {
+        asset_code: Symbol::short("USDT"),
+        price: 1000,
+    });
+    
+    // Should fail with less than 5 assets
+    let result = env.try_invoke_contract::<(), (
+        soroban_sdk::xdr::ScVal,
+        soroban_sdk::xdr::ScVal,
+    )>(
+        &contract_id,
+        &Symbol::short("update_prices_batch"),
+        (&price_updates, &admin).into_val(&env),
+    );
+    assert!(result.is_err());
+}
+
+#[test]
+fn test_batch_price_update_unauthorized() {
+    let env = Env::default();
+    let contract_id = env.register_contract(None, TimeLockedUpgradeContract);
+    let client = TimeLockedUpgradeClient::new(&env, &contract_id);
+    
+    let admin = Address::generate(&env);
+    let unauthorized_user = Address::generate(&env);
+    client.initialize(&admin);
+    
+    // Create price updates
+    let mut price_updates = Vec::new(&env);
+    for i in 0..5 {
+        price_updates.push_back(PriceUpdate {
+            asset_code: Symbol::short(&format!("Asset{}", i)),
+            price: 1000 + i,
+        });
+    }
+    
+    // Try to update as unauthorized user (should fail)
+    let result = env.try_invoke_contract::<(), (
+        soroban_sdk::xdr::ScVal,
+        soroban_sdk::xdr::ScVal,
+    )>(
+        &contract_id,
+        &Symbol::short("update_prices_batch"),
+        (&price_updates, &unauthorized_user).into_val(&env),
+    );
+    assert!(result.is_err());
+}
+
+#[test]
+fn test_batch_price_update_timestamps() {
+    let env = Env::default();
+    let contract_id = env.register_contract(None, TimeLockedUpgradeContract);
+    let client = TimeLockedUpgradeClient::new(&env, &contract_id);
+    
+    let admin = Address::generate(&env);
+    client.initialize(&admin);
+    
+    // Set initial timestamp
+    let initial_time = 1000000;
+    env.ledger().set_timestamp(initial_time);
+    
+    // Create price updates
+    let mut price_updates = Vec::new(&env);
+    for i in 0..5 {
+        price_updates.push_back(PriceUpdate {
+            asset_code: Symbol::short(&format!("Asset{}", i)),
+            price: 1000 + i,
+        });
+    }
+    
+    // Update prices
+    client.update_prices_batch(&price_updates, &admin);
+    
+    // Check that timestamps are set correctly
+    let btc_price = client.get_price(&Symbol::short("Asset0"));
+    assert!(btc_price.is_some());
+    assert_eq!(btc_price.unwrap().timestamp, initial_time);
+    
+    // Advance time and update again
+    let new_time = initial_time + 3600; // 1 hour later
+    env.ledger().set_timestamp(new_time);
+    
+    // Update with new prices
+    let mut new_price_updates = Vec::new(&env);
+    new_price_updates.push_back(PriceUpdate {
+        asset_code: Symbol::short("Asset0"),
+        price: 2000,
+    });
+    new_price_updates.push_back(PriceUpdate {
+        asset_code: Symbol::short("Asset1"),
+        price: 3000,
+    });
+    new_price_updates.push_back(PriceUpdate {
+        asset_code: Symbol::short("Asset2"),
+        price: 4000,
+    });
+    new_price_updates.push_back(PriceUpdate {
+        asset_code: Symbol::short("Asset3"),
+        price: 5000,
+    });
+    new_price_updates.push_back(PriceUpdate {
+        asset_code: Symbol::short("Asset4"),
+        price: 6000,
+    });
+    
+    client.update_prices_batch(&new_price_updates, &admin);
+    
+    // Verify timestamps were updated
+    let updated_price = client.get_price(&Symbol::short("Asset0"));
+    assert!(updated_price.is_some());
+    assert_eq!(updated_price.unwrap().timestamp, new_time);
+    assert_eq!(updated_price.unwrap().price, 2000);
 }


### PR DESCRIPTION
- Add update_prices_batch(Vec) function for multi-asset price updates
- Implement AssetPrice and PriceUpdate data structures
- Add price storage with Map<Symbol, AssetPrice>
- Enforce minimum 5+ assets per batch for fee efficiency
- Add get_price() and get_all_prices() query functions
- Include comprehensive test suite for batch updates
- Add usage example and updated documentation
- Maintain admin-only authorization for price updates

Resolves #195: Allow relayer to update 5+ assets in single transaction to save on submission fees