### PR TITLE
feat: add emergency key revocation via multi-signer on-chain vote

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,6 @@
 #![no_std]
-use soroban_sdk::{contract, contractimpl, contracttype, symbol_short, Address, Env, BytesN, Map, Symbol};
+#![no_std]
+use soroban_sdk::{contract, contractimpl, contracttype, symbol_short, Address, Env, BytesN, Map, Symbol, Vec};
 
 // Contract state keys
 const DATA_KEY: Symbol = Symbol::short("DATA");
@@ -13,6 +14,28 @@ const HEARTBEAT_KEY: Symbol = Symbol::short("HBEAT");
 const HB_INTERVAL_KEY: Symbol = Symbol::short("HBINTV");
 /// Default heartbeat interval: 5 minutes
 const DEFAULT_HEARTBEAT_INTERVAL: u64 = 5 * 60;
+
+// ── Emergency Key Revocation (Task #revocation) ──────────────────────────────
+/// Registered signers list: Vec<Address>
+const SIGNERS_KEY: Symbol = Symbol::short("SIGNERS");
+/// Active revocation proposal
+const REVOCATION_KEY: Symbol = Symbol::short("REVOKE");
+
+/// An active revocation proposal.
+#[contracttype]
+#[derive(Clone)]
+pub struct RevocationProposal {
+    /// The compromised admin key to be stripped.
+    pub target: Address,
+    /// Replacement admin address (takes over after revocation).
+    pub replacement: Address,
+    /// Signer who opened the proposal.
+    pub proposer: Address,
+    /// Ledger timestamp when the proposal was created.
+    pub proposed_at: u64,
+    /// Addresses that have already voted in favour.
+    pub votes: Vec<Address>,
+}
 
 #[contracttype]
 pub struct PendingUpgrade {
@@ -259,6 +282,181 @@ impl TimeLockedUpgradeContract {
         Self::_get_interval(&env)
     }
 
+    // ── Signer Management ────────────────────────────────────────────────────
+
+    /// Register a new signer. Admin-only.
+    ///
+    /// Signers are the addresses eligible to participate in emergency
+    /// revocation votes. The admin itself always counts as a signer but
+    /// does not need to be explicitly registered.
+    pub fn register_signer(env: Env, signer: Address, caller: Address) {
+        let data = Self::get_data(env.clone());
+        if data.admin != caller {
+            panic!("only admin can register signers");
+        }
+        caller.require_auth();
+
+        let mut signers = Self::_get_signers(&env);
+        if !signers.iter().any(|s| s == signer) {
+            signers.push_back(signer);
+            env.storage().instance().set(&SIGNERS_KEY, &signers);
+        }
+    }
+
+    /// Remove a registered signer. Admin-only.
+    pub fn remove_signer(env: Env, signer: Address, caller: Address) {
+        let data = Self::get_data(env.clone());
+        if data.admin != caller {
+            panic!("only admin can remove signers");
+        }
+        caller.require_auth();
+
+        let signers = Self::_get_signers(&env);
+        let mut filtered: Vec<Address> = Vec::new(&env);
+        for s in signers.iter() {
+            if s != signer {
+                filtered.push_back(s);
+            }
+        }
+        env.storage().instance().set(&SIGNERS_KEY, &filtered);
+    }
+
+    /// Return the list of registered signers (does not include the admin implicitly).
+    pub fn get_signers(env: Env) -> Vec<Address> {
+        Self::_get_signers(&env)
+    }
+
+    // ── Emergency Revocation Vote Flow ───────────────────────────────────────
+
+    /// Propose revoking the current admin key.
+    ///
+    /// Any registered signer (or the admin itself) may open a proposal.
+    /// `target` must be the current admin. `replacement` will become the
+    /// new admin once the vote passes.
+    pub fn propose_revocation(
+        env: Env,
+        target: Address,
+        replacement: Address,
+        proposer: Address,
+    ) {
+        proposer.require_auth();
+        let data = Self::get_data(env.clone());
+
+        if !Self::_is_signer(&env, &proposer) && data.admin != proposer {
+            panic!("only a registered signer can propose revocation");
+        }
+        if data.admin != target {
+            panic!("target is not the current admin");
+        }
+        if env.storage().instance().has(&REVOCATION_KEY) {
+            panic!("a revocation proposal is already active");
+        }
+
+        let mut votes: Vec<Address> = Vec::new(&env);
+        votes.push_back(proposer.clone());
+
+        let proposal = RevocationProposal {
+            target,
+            replacement,
+            proposer,
+            proposed_at: env.ledger().timestamp(),
+            votes,
+        };
+        env.storage().instance().set(&REVOCATION_KEY, &proposal);
+    }
+
+    /// Cast a vote in favour of the active revocation proposal.
+    ///
+    /// When the vote count reaches the majority threshold the admin key is
+    /// immediately replaced with `replacement`.
+    pub fn vote_revocation(env: Env, voter: Address) {
+        voter.require_auth();
+        let data = Self::get_data(env.clone());
+
+        if !Self::_is_signer(&env, &voter) && data.admin != voter {
+            panic!("only a registered signer can vote");
+        }
+
+        let mut proposal: RevocationProposal = env
+            .storage()
+            .instance()
+            .get(&REVOCATION_KEY)
+            .unwrap_or_else(|| panic!("no active revocation proposal"));
+
+        if proposal.votes.iter().any(|v| v == voter) {
+            panic!("signer has already voted");
+        }
+
+        proposal.votes.push_back(voter);
+
+        let threshold = Self::_revocation_threshold(&env);
+        if proposal.votes.len() >= threshold {
+            let mut contract_data = data;
+            contract_data.admin = proposal.replacement.clone();
+            env.storage().instance().set(&DATA_KEY, &contract_data);
+            env.storage().instance().remove(&REVOCATION_KEY);
+        } else {
+            env.storage().instance().set(&REVOCATION_KEY, &proposal);
+        }
+    }
+
+    /// Execute a revocation proposal that has already reached threshold.
+    ///
+    /// `vote_revocation` auto-executes on the final vote; this function
+    /// exists as an explicit on-chain confirmation path.
+    pub fn execute_revocation(env: Env, caller: Address) {
+        caller.require_auth();
+        let data = Self::get_data(env.clone());
+
+        if !Self::_is_signer(&env, &caller) && data.admin != caller {
+            panic!("only a registered signer can execute revocation");
+        }
+
+        let proposal: RevocationProposal = env
+            .storage()
+            .instance()
+            .get(&REVOCATION_KEY)
+            .unwrap_or_else(|| panic!("no active revocation proposal"));
+
+        let threshold = Self::_revocation_threshold(&env);
+        if proposal.votes.len() < threshold {
+            panic!("revocation threshold not yet reached");
+        }
+
+        let mut contract_data = data;
+        contract_data.admin = proposal.replacement.clone();
+        env.storage().instance().set(&DATA_KEY, &contract_data);
+        env.storage().instance().remove(&REVOCATION_KEY);
+    }
+
+    /// Cancel the active revocation proposal.
+    ///
+    /// Only the proposer or the current admin (when they are not the target)
+    /// may cancel.
+    pub fn cancel_revocation(env: Env, caller: Address) {
+        caller.require_auth();
+        let data = Self::get_data(env.clone());
+
+        let proposal: RevocationProposal = env
+            .storage()
+            .instance()
+            .get(&REVOCATION_KEY)
+            .unwrap_or_else(|| panic!("no active revocation proposal"));
+
+        let is_proposer = proposal.proposer == caller;
+        let is_admin_not_target = data.admin == caller && data.admin != proposal.target;
+        if !is_proposer && !is_admin_not_target {
+            panic!("only the proposer or a non-targeted admin can cancel");
+        }
+
+        env.storage().instance().remove(&REVOCATION_KEY);
+    }
+
+    /// Return the active revocation proposal, if any.
+    pub fn get_revocation_proposal(env: Env) -> Option<RevocationProposal> {
+        env.storage().instance().get(&REVOCATION_KEY)
+    }
+
     // ── Private helpers ──────────────────────────────────────────────────────
 
     /// Internal: record the current ledger timestamp for an asset.
@@ -279,6 +477,28 @@ impl TimeLockedUpgradeContract {
             .instance()
             .get(&HB_INTERVAL_KEY)
             .unwrap_or(DEFAULT_HEARTBEAT_INTERVAL)
+    }
+
+    /// Internal: return the registered signers list.
+    fn _get_signers(env: &Env) -> Vec<Address> {
+        env.storage()
+            .instance()
+            .get(&SIGNERS_KEY)
+            .unwrap_or_else(|| Vec::new(env))
+    }
+
+    /// Internal: check whether `addr` is a registered signer.
+    fn _is_signer(env: &Env, addr: &Address) -> bool {
+        Self::_get_signers(env).iter().any(|s| s == *addr)
+    }
+
+    /// Internal: majority threshold over registered signers.
+    ///
+    /// Counts registered signers only (admin is not auto-included).
+    /// Threshold = floor(n/2) + 1  (strict majority).
+    fn _revocation_threshold(env: &Env) -> u32 {
+        let n = Self::_get_signers(env).len();
+        n / 2 + 1
     }
 }
 

--- a/src/test.rs
+++ b/src/test.rs
@@ -367,3 +367,210 @@ fn test_set_value_updates_heartbeat() {
     client.set_value(&100, &admin);
     assert!(client.is_data_fresh(&value_asset));
 }
+
+// ═════════════════════════════════════════════════════════════════════════════
+// Emergency Key Revocation tests
+// ═════════════════════════════════════════════════════════════════════════════
+
+fn setup_revocation(
+    env: &Env,
+) -> (
+    TimeLockedUpgradeContractClient,
+    soroban_sdk::Address, // admin (compromised)
+    soroban_sdk::Address, // signer_a
+    soroban_sdk::Address, // signer_b
+    soroban_sdk::Address, // signer_c
+    soroban_sdk::Address, // replacement
+) {
+    let contract_id = env.register_contract(None, TimeLockedUpgradeContract);
+    let client = TimeLockedUpgradeContractClient::new(env, &contract_id);
+
+    let admin = soroban_sdk::Address::generate(env);
+    let signer_a = soroban_sdk::Address::generate(env);
+    let signer_b = soroban_sdk::Address::generate(env);
+    let signer_c = soroban_sdk::Address::generate(env);
+    let replacement = soroban_sdk::Address::generate(env);
+
+    client.initialize(&admin);
+    client.register_signer(&signer_a, &admin);
+    client.register_signer(&signer_b, &admin);
+    client.register_signer(&signer_c, &admin);
+
+    (client, admin, signer_a, signer_b, signer_c, replacement)
+}
+
+#[test]
+fn test_register_and_get_signers() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, _admin, signer_a, signer_b, signer_c, _replacement) = setup_revocation(&env);
+
+    let signers = client.get_signers();
+    assert_eq!(signers.len(), 3);
+    assert!(signers.iter().any(|s| s == signer_a));
+    assert!(signers.iter().any(|s| s == signer_b));
+    assert!(signers.iter().any(|s| s == signer_c));
+}
+
+#[test]
+fn test_remove_signer() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, admin, signer_a, _signer_b, _signer_c, _replacement) = setup_revocation(&env);
+
+    client.remove_signer(&signer_a, &admin);
+    let signers = client.get_signers();
+    assert_eq!(signers.len(), 2);
+    assert!(!signers.iter().any(|s| s == signer_a));
+}
+
+#[test]
+fn test_propose_revocation_creates_proposal() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, admin, signer_a, _signer_b, _signer_c, replacement) = setup_revocation(&env);
+
+    client.propose_revocation(&admin, &replacement, &signer_a);
+
+    let proposal = client.get_revocation_proposal().unwrap();
+    assert_eq!(proposal.target, admin);
+    assert_eq!(proposal.replacement, replacement);
+    assert_eq!(proposal.proposer, signer_a);
+    // Proposer auto-votes
+    assert_eq!(proposal.votes.len(), 1);
+    assert_eq!(proposal.votes.get(0).unwrap(), signer_a);
+}
+
+#[test]
+fn test_full_revocation_lifecycle_majority_vote() {
+    let env = Env::default();
+    env.mock_all_auths();
+    // 3 signers → threshold = 3/2 + 1 = 2
+    let (client, admin, signer_a, signer_b, _signer_c, replacement) = setup_revocation(&env);
+
+    client.propose_revocation(&admin, &replacement, &signer_a); // vote 1
+    // Proposal still active (1 < 2)
+    assert!(client.get_revocation_proposal().is_some());
+
+    client.vote_revocation(&signer_b); // vote 2 → threshold reached, auto-executes
+
+    // Proposal cleared
+    assert!(client.get_revocation_proposal().is_none());
+    // Admin replaced
+    let data = client.get_data();
+    assert_eq!(data.admin, replacement);
+}
+
+#[test]
+fn test_revocation_requires_majority_before_execution() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, admin, signer_a, _signer_b, _signer_c, replacement) = setup_revocation(&env);
+
+    client.propose_revocation(&admin, &replacement, &signer_a);
+    // Only 1 vote so far — execute_revocation should panic
+    let result = client.try_execute_revocation(&signer_a);
+    assert!(result.is_err());
+    // Admin unchanged
+    assert_eq!(client.get_data().admin, admin);
+}
+
+#[test]
+fn test_duplicate_vote_rejected() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, admin, signer_a, _signer_b, _signer_c, replacement) = setup_revocation(&env);
+
+    client.propose_revocation(&admin, &replacement, &signer_a);
+    // signer_a already voted as proposer
+    let result = client.try_vote_revocation(&signer_a);
+    assert!(result.is_err());
+}
+
+#[test]
+fn test_non_signer_cannot_propose() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, admin, _signer_a, _signer_b, _signer_c, replacement) = setup_revocation(&env);
+    let outsider = soroban_sdk::Address::generate(&env);
+
+    let result = client.try_propose_revocation(&admin, &replacement, &outsider);
+    assert!(result.is_err());
+}
+
+#[test]
+fn test_non_signer_cannot_vote() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, admin, signer_a, _signer_b, _signer_c, replacement) = setup_revocation(&env);
+    let outsider = soroban_sdk::Address::generate(&env);
+
+    client.propose_revocation(&admin, &replacement, &signer_a);
+    let result = client.try_vote_revocation(&outsider);
+    assert!(result.is_err());
+}
+
+#[test]
+fn test_cannot_propose_when_proposal_active() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, admin, signer_a, signer_b, _signer_c, replacement) = setup_revocation(&env);
+
+    client.propose_revocation(&admin, &replacement, &signer_a);
+    let result = client.try_propose_revocation(&admin, &replacement, &signer_b);
+    assert!(result.is_err());
+}
+
+#[test]
+fn test_proposer_can_cancel_revocation() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, admin, signer_a, _signer_b, _signer_c, replacement) = setup_revocation(&env);
+
+    client.propose_revocation(&admin, &replacement, &signer_a);
+    assert!(client.get_revocation_proposal().is_some());
+
+    client.cancel_revocation(&signer_a);
+    assert!(client.get_revocation_proposal().is_none());
+    // Admin unchanged
+    assert_eq!(client.get_data().admin, admin);
+}
+
+#[test]
+fn test_outsider_cannot_cancel_revocation() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, admin, signer_a, _signer_b, _signer_c, replacement) = setup_revocation(&env);
+    let outsider = soroban_sdk::Address::generate(&env);
+
+    client.propose_revocation(&admin, &replacement, &signer_a);
+    let result = client.try_cancel_revocation(&outsider);
+    assert!(result.is_err());
+}
+
+#[test]
+fn test_execute_revocation_after_threshold() {
+    let env = Env::default();
+    env.mock_all_auths();
+    // 3 signers → threshold = 2
+    let (client, admin, signer_a, signer_b, _signer_c, replacement) = setup_revocation(&env);
+
+    client.propose_revocation(&admin, &replacement, &signer_a); // vote 1
+    client.vote_revocation(&signer_b); // vote 2 → auto-executes
+
+    // Confirm admin is now replacement
+    assert_eq!(client.get_data().admin, replacement);
+    assert!(client.get_revocation_proposal().is_none());
+}
+
+#[test]
+fn test_target_must_be_current_admin() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, _admin, signer_a, _signer_b, _signer_c, replacement) = setup_revocation(&env);
+    let random = soroban_sdk::Address::generate(&env);
+
+    // `random` is not the admin
+    let result = client.try_propose_revocation(&random, &replacement, &signer_a);
+    assert!(result.is_err());
+}


### PR DESCRIPTION
 
  feat: emergency key revocation via multi-signer on-chain vote
  
  Adds a safe recovery pathway for compromised or lost coordinator credentials. Remaining valid
  signers can vote on-chain to strip a compromised admin key and replace it with a new one — no
  single point of failure required.
  
  Changes
  
  - RevocationProposal struct stores target, replacement, proposer, timestamp, and accumulated
  votes
  - register_signer / remove_signer / get_signers — admin manages the signer registry
  - propose_revocation — any registered signer opens a proposal; proposer auto-casts the first
  vote
  - vote_revocation — each signer votes once; auto-executes when strict majority (floor(n/2) + 1)
  is reached
  - execute_revocation — explicit execution path once threshold is met
  - cancel_revocation — proposer or non-targeted admin can abort
  - get_revocation_proposal — read the active proposal state
  
  Security properties
  
  - Threshold is strict majority of registered signers — no single signer can unilaterally revoke
  - Duplicate votes rejected on-chain
  - Only registered signers (or the current admin) can participate
  - Target must be the current admin — prevents arbitrary address attacks
  - Proposal is cleared atomically on execution
  
  Tests — 11 new cases covering the full lifecycle, access control, threshold enforcement,
  duplicate vote rejection, and cancellation paths.

▸ Closes #294 