### PR TITLE
feat(escrow): implement relayer staking collateral escrow (sdk 20 com…

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ members = [
     "contracts/hello-world",
     "contracts/ledger-time-helper",
     "contracts/price-oracle",
+    "contracts/relayer-escrow",
 ]
 resolver = "2"
 

--- a/contracts/relayer-escrow/Cargo.toml
+++ b/contracts/relayer-escrow/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "relayer_staking_escrow"
+version = "0.1.0"
+edition = "2021"
+publish = false
+
+[lib]
+crate-type = ["cdylib", "rlib"]
+doctest = false
+
+[dependencies]
+soroban-sdk = { workspace = true }
+
+[dev-dependencies]
+soroban-sdk = { workspace = true, features = ["testutils"] }

--- a/contracts/relayer-escrow/Makefile
+++ b/contracts/relayer-escrow/Makefile
@@ -1,0 +1,16 @@
+default: build
+
+all: test
+
+test: build
+	cargo test
+
+build:
+	stellar contract build
+	@ls -l target/wasm32v1-none/release/*.wasm
+
+fmt:
+	cargo fmt --all
+
+clean:
+	cargo clean

--- a/contracts/relayer-escrow/README.md
+++ b/contracts/relayer-escrow/README.md
@@ -1,0 +1,163 @@
+# Relayer Staking Collateral Escrow
+
+A Soroban smart contract on the Stellar network that lets relayers deposit and withdraw SAC-compatible tokens as collateral. Staked balances are stored per-relayer in persistent storage and the contract enforces authorization on every state-changing call.
+
+---
+
+## Contract Functions
+
+| Function | Description |
+|---|---|
+| `initialize(token)` | One-time setup — stores the SAC token address |
+| `deposit_stake(relayer, amount)` | Transfers tokens from relayer into escrow, updates balance |
+| `withdraw_stake(relayer, amount)` | Returns tokens from escrow to relayer |
+| `get_stake(relayer)` | Returns the relayer's current staked balance |
+| `get_token()` | Returns the SAC token address |
+
+---
+
+## Storage Layout
+
+| Key | Type | Description |
+|---|---|---|
+| `Token` | Instance | SAC token address (set once at init) |
+| `Stake(Address)` | Persistent | Staked balance per relayer |
+
+---
+
+## Security Properties
+
+- `relayer.require_auth()` is called before any state change
+- Amount validation (`> 0`) before any transfer
+- Withdrawal is bounded by the relayer's stored balance
+- Balance is updated **before** the outbound token transfer (checks-effects-interactions pattern)
+
+---
+
+## Prerequisites
+
+- [Rust](https://rustup.rs/) with `wasm32-unknown-unknown` target
+- [Stellar CLI](https://developers.stellar.org/docs/tools/developer-tools/cli/install-cli)
+
+```bash
+rustup target add wasm32-unknown-unknown
+cargo install --locked stellar-cli --features opt
+```
+
+---
+
+## Build
+
+From the workspace root:
+
+```bash
+stellar contract build
+```
+
+Or from this contract's directory:
+
+```bash
+stellar contract build
+```
+
+The compiled WASM lands at:
+```
+target/wasm32v1-none/release/relayer_staking_escrow.wasm
+```
+
+---
+
+## Run Tests
+
+```bash
+cargo test -p relayer_staking_escrow
+```
+
+---
+
+## Deploy to Stellar Testnet
+
+### 1. Create and fund a testnet identity
+
+```bash
+stellar keys generate --global alice --network testnet
+stellar keys fund alice --network testnet
+```
+
+### 2. Deploy the contract
+
+```bash
+stellar contract deploy \
+  --wasm target/wasm32v1-none/release/relayer_staking_escrow.wasm \
+  --source alice \
+  --network testnet
+```
+
+This prints a contract ID, e.g. `CXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX`.
+
+### 3. Initialize with a SAC token
+
+Replace `<CONTRACT_ID>` and `<TOKEN_ADDRESS>` with your values:
+
+```bash
+stellar contract invoke \
+  --id <CONTRACT_ID> \
+  --source alice \
+  --network testnet \
+  -- initialize \
+  --token <TOKEN_ADDRESS>
+```
+
+### 4. Deposit stake
+
+```bash
+stellar contract invoke \
+  --id <CONTRACT_ID> \
+  --source alice \
+  --network testnet \
+  -- deposit_stake \
+  --relayer <RELAYER_ADDRESS> \
+  --amount 1000000
+```
+
+### 5. Check balance
+
+```bash
+stellar contract invoke \
+  --id <CONTRACT_ID> \
+  --network testnet \
+  -- get_stake \
+  --relayer <RELAYER_ADDRESS>
+```
+
+### 6. Withdraw stake
+
+```bash
+stellar contract invoke \
+  --id <CONTRACT_ID> \
+  --source alice \
+  --network testnet \
+  -- withdraw_stake \
+  --relayer <RELAYER_ADDRESS> \
+  --amount 500000
+```
+
+---
+
+## Testnet RPC
+
+```
+https://soroban-testnet.stellar.org
+```
+
+Network passphrase: `Test SDF Network ; September 2015`
+
+---
+
+## Events
+
+| Topic | Data | Emitted by |
+|---|---|---|
+| `init` | `(token_address)` | `initialize` |
+| `deposit` | `(relayer, amount)` | `deposit_stake` |
+| `withdraw` | `(relayer, amount)` | `withdraw_stake` |

--- a/contracts/relayer-escrow/src/lib.rs
+++ b/contracts/relayer-escrow/src/lib.rs
@@ -1,0 +1,204 @@
+//! Relayer Staking Collateral Escrow
+//!
+//! Allows relayers to deposit and withdraw a SAC-compatible token as collateral.
+//! Staked balances are stored per-relayer in persistent storage so they survive
+//! ledger TTL extensions. The contract holds the tokens in its own account and
+//! enforces authorization on every state-changing call.
+
+#![no_std]
+
+use soroban_sdk::{
+    contract, contracterror, contractimpl, contracttype, token, Address, Env,
+};
+
+// ---------------------------------------------------------------------------
+// Storage keys
+// ---------------------------------------------------------------------------
+
+/// Storage key enum used for all contract state.
+///
+/// `Token`  — instance storage (one per contract, cheap to read on every call).
+/// `Stake`  — persistent storage (one slot per relayer, survives ledger TTL).
+#[contracttype]
+pub enum DataKey {
+    /// The SAC token address accepted by this escrow.
+    Token,
+    /// Staked balance for a specific relayer.
+    Stake(Address),
+}
+
+// ---------------------------------------------------------------------------
+// Error codes
+// ---------------------------------------------------------------------------
+
+#[contracterror]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
+#[repr(u32)]
+pub enum Error {
+    /// Contract has already been initialized.
+    AlreadyInitialized = 1,
+    /// Contract has not been initialized yet.
+    NotInitialized = 2,
+    /// Amount must be greater than zero.
+    InvalidAmount = 3,
+    /// Withdrawal amount exceeds the relayer's staked balance.
+    InsufficientBalance = 4,
+}
+
+// ---------------------------------------------------------------------------
+// Contract
+// ---------------------------------------------------------------------------
+
+#[contract]
+pub struct RelayerStakingEscrow;
+
+#[contractimpl]
+impl RelayerStakingEscrow {
+    // -----------------------------------------------------------------------
+    // Admin / setup
+    // -----------------------------------------------------------------------
+
+    /// Initialize the escrow with the SAC token it will accept.
+    ///
+    /// Must be called exactly once. Subsequent calls return `Error::AlreadyInitialized`.
+    pub fn initialize(env: Env, token: Address) -> Result<(), Error> {
+        if env.storage().instance().has(&DataKey::Token) {
+            return Err(Error::AlreadyInitialized);
+        }
+
+        env.storage().instance().set(&DataKey::Token, &token);
+
+        // Emit initialization event so indexers can track contract lifecycle.
+        env.events().publish(
+            (soroban_sdk::symbol_short!("init"),),
+            (token,),
+        );
+
+        Ok(())
+    }
+
+    // -----------------------------------------------------------------------
+    // Core staking functions
+    // -----------------------------------------------------------------------
+
+    /// Deposit `amount` tokens from `relayer` into the escrow.
+    ///
+    /// - Requires authorization from `relayer`.
+    /// - Transfers tokens from the relayer's account into this contract.
+    /// - Adds `amount` to the relayer's persistent staked balance.
+    /// - Emits a `deposit` event on success.
+    pub fn deposit_stake(env: Env, relayer: Address, amount: i128) -> Result<(), Error> {
+        // Guard: contract must be initialized.
+        if !env.storage().instance().has(&DataKey::Token) {
+            return Err(Error::NotInitialized);
+        }
+
+        // Guard: amount must be positive.
+        if amount <= 0 {
+            return Err(Error::InvalidAmount);
+        }
+
+        // Require the relayer to sign this transaction.
+        relayer.require_auth();
+
+        // Pull the token address from instance storage.
+        let token_address: Address = env
+            .storage()
+            .instance()
+            .get(&DataKey::Token)
+            .unwrap(); // safe: we checked has() above
+
+        // Transfer tokens from the relayer into this contract.
+        let token_client = token::TokenClient::new(&env, &token_address);
+        token_client.transfer(&relayer, &env.current_contract_address(), &amount);
+
+        // Update the relayer's staked balance in persistent storage.
+        let key = DataKey::Stake(relayer.clone());
+        let current: i128 = env.storage().persistent().get(&key).unwrap_or(0);
+        env.storage().persistent().set(&key, &(current + amount));
+
+        // Emit deposit event: topic = "deposit", data = (relayer, amount).
+        env.events().publish(
+            (soroban_sdk::symbol_short!("deposit"),),
+            (relayer, amount),
+        );
+
+        Ok(())
+    }
+
+    /// Withdraw `amount` tokens from the escrow back to `relayer`.
+    ///
+    /// - Requires authorization from `relayer`.
+    /// - Fails with `Error::InsufficientBalance` if the relayer has less than `amount` staked.
+    /// - Emits a `withdraw` event on success.
+    pub fn withdraw_stake(env: Env, relayer: Address, amount: i128) -> Result<(), Error> {
+        // Guard: contract must be initialized.
+        if !env.storage().instance().has(&DataKey::Token) {
+            return Err(Error::NotInitialized);
+        }
+
+        // Guard: amount must be positive.
+        if amount <= 0 {
+            return Err(Error::InvalidAmount);
+        }
+
+        // Require the relayer to sign this transaction.
+        relayer.require_auth();
+
+        // Check the relayer has enough staked.
+        let key = DataKey::Stake(relayer.clone());
+        let current: i128 = env.storage().persistent().get(&key).unwrap_or(0);
+        if amount > current {
+            return Err(Error::InsufficientBalance);
+        }
+
+        // Pull the token address from instance storage.
+        let token_address: Address = env
+            .storage()
+            .instance()
+            .get(&DataKey::Token)
+            .unwrap(); // safe: we checked has() above
+
+        // Update balance before the external call (checks-effects-interactions).
+        let new_balance = current - amount;
+        env.storage().persistent().set(&key, &new_balance);
+
+        // Transfer tokens from this contract back to the relayer.
+        let token_client = token::TokenClient::new(&env, &token_address);
+        token_client.transfer(&env.current_contract_address(), &relayer, &amount);
+
+        // Emit withdrawal event: topic = "withdraw", data = (relayer, amount).
+        env.events().publish(
+            (soroban_sdk::symbol_short!("withdraw"),),
+            (relayer, amount),
+        );
+
+        Ok(())
+    }
+
+    // -----------------------------------------------------------------------
+    // Read-only queries
+    // -----------------------------------------------------------------------
+
+    /// Return the staked balance for `relayer`. Returns 0 if never deposited.
+    pub fn get_stake(env: Env, relayer: Address) -> i128 {
+        env.storage()
+            .persistent()
+            .get(&DataKey::Stake(relayer))
+            .unwrap_or(0)
+    }
+
+    /// Return the SAC token address this escrow was initialized with.
+    pub fn get_token(env: Env) -> Result<Address, Error> {
+        env.storage()
+            .instance()
+            .get(&DataKey::Token)
+            .ok_or(Error::NotInitialized)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+mod test;

--- a/contracts/relayer-escrow/src/test.rs
+++ b/contracts/relayer-escrow/src/test.rs
@@ -1,0 +1,382 @@
+#![cfg(test)]
+
+use soroban_sdk::{
+    testutils::{Address as _, Events},
+    token::{StellarAssetClient, TokenClient},
+    Address, Env,
+};
+
+use crate::{Error, RelayerStakingEscrowClient};
+
+// ---------------------------------------------------------------------------
+// Test helpers
+// ---------------------------------------------------------------------------
+
+/// Deploy a fresh SAC token and return (token_address, admin_address).
+/// In soroban-sdk 20, register_stellar_asset_contract returns Address directly.
+fn create_token(env: &Env) -> (Address, Address) {
+    let admin = Address::generate(env);
+    let token_address = env.register_stellar_asset_contract(admin.clone());
+    (token_address, admin)
+}
+
+/// Deploy the escrow contract and return its client.
+fn create_escrow(env: &Env) -> RelayerStakingEscrowClient {
+    let contract_id = env.register_contract(None, crate::RelayerStakingEscrow);
+    RelayerStakingEscrowClient::new(env, &contract_id)
+}
+
+/// Mint `amount` tokens to `recipient`. Must be called within mock_all_auths scope.
+fn mint(env: &Env, token: &Address, recipient: &Address, amount: i128) {
+    StellarAssetClient::new(env, token).mint(recipient, &amount);
+}
+
+// ---------------------------------------------------------------------------
+// initialize
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_initialize_stores_token() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (token, _admin) = create_token(&env);
+    let escrow = create_escrow(&env);
+
+    escrow.initialize(&token);
+
+    assert_eq!(escrow.get_token(), token);
+}
+
+#[test]
+fn test_initialize_twice_returns_error() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (token, _admin) = create_token(&env);
+    let escrow = create_escrow(&env);
+
+    escrow.initialize(&token);
+    let result = escrow.try_initialize(&token);
+
+    assert_eq!(result, Err(Ok(Error::AlreadyInitialized)));
+}
+
+// ---------------------------------------------------------------------------
+// deposit_stake
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_deposit_stake_increases_balance() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (token, _admin) = create_token(&env);
+    let escrow = create_escrow(&env);
+    escrow.initialize(&token);
+
+    let relayer = Address::generate(&env);
+    mint(&env, &token, &relayer, 1_000);
+
+    escrow.deposit_stake(&relayer, &500);
+
+    assert_eq!(escrow.get_stake(&relayer), 500);
+}
+
+#[test]
+fn test_deposit_stake_multiple_deposits_accumulate() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (token, _admin) = create_token(&env);
+    let escrow = create_escrow(&env);
+    escrow.initialize(&token);
+
+    let relayer = Address::generate(&env);
+    mint(&env, &token, &relayer, 2_000);
+
+    escrow.deposit_stake(&relayer, &700);
+    escrow.deposit_stake(&relayer, &300);
+
+    assert_eq!(escrow.get_stake(&relayer), 1_000);
+}
+
+#[test]
+fn test_deposit_stake_zero_amount_returns_error() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (token, _admin) = create_token(&env);
+    let escrow = create_escrow(&env);
+    escrow.initialize(&token);
+
+    let relayer = Address::generate(&env);
+    let result = escrow.try_deposit_stake(&relayer, &0);
+
+    assert_eq!(result, Err(Ok(Error::InvalidAmount)));
+}
+
+#[test]
+fn test_deposit_stake_negative_amount_returns_error() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (token, _admin) = create_token(&env);
+    let escrow = create_escrow(&env);
+    escrow.initialize(&token);
+
+    let relayer = Address::generate(&env);
+    let result = escrow.try_deposit_stake(&relayer, &-100);
+
+    assert_eq!(result, Err(Ok(Error::InvalidAmount)));
+}
+
+#[test]
+fn test_deposit_stake_requires_relayer_auth() {
+    let env = Env::default();
+
+    // Initialize with mocked auths, then clear them.
+    let (token, _admin) = {
+        env.mock_all_auths();
+        create_token(&env)
+    };
+    let escrow = create_escrow(&env);
+    escrow.initialize(&token);
+
+    // Now clear all mocked auths — deposit should fail without relayer signature.
+    env.set_auths(&[]);
+    let relayer = Address::generate(&env);
+    let result = escrow.try_deposit_stake(&relayer, &500);
+    assert!(result.is_err());
+}
+
+#[test]
+fn test_deposit_stake_emits_event() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (token, _admin) = create_token(&env);
+    let escrow = create_escrow(&env);
+    escrow.initialize(&token);
+
+    let relayer = Address::generate(&env);
+    mint(&env, &token, &relayer, 1_000);
+
+    escrow.deposit_stake(&relayer, &400);
+
+    let events = env.events().all();
+    // The last event should be our deposit event.
+    let last = events.last().unwrap();
+    // topic[0] should be the symbol "deposit"
+    let topic: soroban_sdk::Symbol = last.1.get(0).unwrap();
+    assert_eq!(topic, soroban_sdk::symbol_short!("deposit"));
+}
+
+#[test]
+fn test_deposit_stake_before_initialize_returns_error() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let escrow = create_escrow(&env);
+    let relayer = Address::generate(&env);
+
+    let result = escrow.try_deposit_stake(&relayer, &100);
+    assert_eq!(result, Err(Ok(Error::NotInitialized)));
+}
+
+// ---------------------------------------------------------------------------
+// get_stake
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_get_stake_returns_zero_for_unknown_relayer() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (token, _admin) = create_token(&env);
+    let escrow = create_escrow(&env);
+    escrow.initialize(&token);
+
+    let relayer = Address::generate(&env);
+    assert_eq!(escrow.get_stake(&relayer), 0);
+}
+
+#[test]
+fn test_get_stake_independent_per_relayer() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (token, _admin) = create_token(&env);
+    let escrow = create_escrow(&env);
+    escrow.initialize(&token);
+
+    let relayer_a = Address::generate(&env);
+    let relayer_b = Address::generate(&env);
+    mint(&env, &token, &relayer_a, 1_000);
+    mint(&env, &token, &relayer_b, 1_000);
+
+    escrow.deposit_stake(&relayer_a, &300);
+    escrow.deposit_stake(&relayer_b, &700);
+
+    assert_eq!(escrow.get_stake(&relayer_a), 300);
+    assert_eq!(escrow.get_stake(&relayer_b), 700);
+}
+
+// ---------------------------------------------------------------------------
+// withdraw_stake
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_withdraw_stake_reduces_balance() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (token, _admin) = create_token(&env);
+    let escrow = create_escrow(&env);
+    escrow.initialize(&token);
+
+    let relayer = Address::generate(&env);
+    mint(&env, &token, &relayer, 1_000);
+
+    escrow.deposit_stake(&relayer, &800);
+    escrow.withdraw_stake(&relayer, &300);
+
+    assert_eq!(escrow.get_stake(&relayer), 500);
+}
+
+#[test]
+fn test_withdraw_stake_full_amount() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (token, _admin) = create_token(&env);
+    let escrow = create_escrow(&env);
+    escrow.initialize(&token);
+
+    let relayer = Address::generate(&env);
+    mint(&env, &token, &relayer, 1_000);
+
+    escrow.deposit_stake(&relayer, &1_000);
+    escrow.withdraw_stake(&relayer, &1_000);
+
+    assert_eq!(escrow.get_stake(&relayer), 0);
+}
+
+#[test]
+fn test_withdraw_stake_exceeds_balance_returns_error() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (token, _admin) = create_token(&env);
+    let escrow = create_escrow(&env);
+    escrow.initialize(&token);
+
+    let relayer = Address::generate(&env);
+    mint(&env, &token, &relayer, 1_000);
+
+    escrow.deposit_stake(&relayer, &500);
+    let result = escrow.try_withdraw_stake(&relayer, &600);
+
+    assert_eq!(result, Err(Ok(Error::InsufficientBalance)));
+}
+
+#[test]
+fn test_withdraw_stake_zero_amount_returns_error() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (token, _admin) = create_token(&env);
+    let escrow = create_escrow(&env);
+    escrow.initialize(&token);
+
+    let relayer = Address::generate(&env);
+    mint(&env, &token, &relayer, 1_000);
+    escrow.deposit_stake(&relayer, &500);
+
+    let result = escrow.try_withdraw_stake(&relayer, &0);
+    assert_eq!(result, Err(Ok(Error::InvalidAmount)));
+}
+
+#[test]
+fn test_withdraw_stake_requires_relayer_auth() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (token, _admin) = create_token(&env);
+    let escrow = create_escrow(&env);
+    escrow.initialize(&token);
+
+    let relayer = Address::generate(&env);
+    mint(&env, &token, &relayer, 1_000);
+    escrow.deposit_stake(&relayer, &500);
+
+    // Remove all mocked auths — withdrawal should fail without relayer signature.
+    env.set_auths(&[]);
+    let result = escrow.try_withdraw_stake(&relayer, &200);
+    assert!(result.is_err());
+}
+
+#[test]
+fn test_withdraw_stake_emits_event() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (token, _admin) = create_token(&env);
+    let escrow = create_escrow(&env);
+    escrow.initialize(&token);
+
+    let relayer = Address::generate(&env);
+    mint(&env, &token, &relayer, 1_000);
+
+    escrow.deposit_stake(&relayer, &600);
+    escrow.withdraw_stake(&relayer, &200);
+
+    let events = env.events().all();
+    let last = events.last().unwrap();
+    let topic: soroban_sdk::Symbol = last.1.get(0).unwrap();
+    assert_eq!(topic, soroban_sdk::symbol_short!("withdraw"));
+}
+
+#[test]
+fn test_withdraw_stake_before_initialize_returns_error() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let escrow = create_escrow(&env);
+    let relayer = Address::generate(&env);
+
+    let result = escrow.try_withdraw_stake(&relayer, &100);
+    assert_eq!(result, Err(Ok(Error::NotInitialized)));
+}
+
+// ---------------------------------------------------------------------------
+// Token balance round-trip
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_token_balances_move_correctly_on_deposit_and_withdraw() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (token, _admin) = create_token(&env);
+    let escrow = create_escrow(&env);
+    escrow.initialize(&token);
+
+    let relayer = Address::generate(&env);
+    mint(&env, &token, &relayer, 1_000);
+
+    let token_client = TokenClient::new(&env, &token);
+
+    // Before deposit: relayer holds all tokens.
+    assert_eq!(token_client.balance(&relayer), 1_000);
+    assert_eq!(token_client.balance(&escrow.address), 0);
+
+    escrow.deposit_stake(&relayer, &600);
+
+    // After deposit: tokens moved to escrow.
+    assert_eq!(token_client.balance(&relayer), 400);
+    assert_eq!(token_client.balance(&escrow.address), 600);
+
+    escrow.withdraw_stake(&relayer, &250);
+
+    // After partial withdrawal: tokens returned to relayer.
+    assert_eq!(token_client.balance(&relayer), 650);
+    assert_eq!(token_client.balance(&escrow.address), 350);
+}


### PR DESCRIPTION
Summary
Implements Issue #259 — Automated Relayer Staking Collateral Escrow

 Changes
- `initialize(env, token)` — stores SAC token address in instance storage
- `deposit_stake(env, relayer, amount)` — pulls tokens from relayer into escrow
- `withdraw_stake(env, relayer, amount)` — returns tokens to relayer with auth check
- `get_stake(env, relayer)` — returns current staked balance

SDK Compatibility (soroban-sdk 20.0.0)
- Used `token::TokenClient` (not TokenClient v21 variant)
- Used `env.register_contract()` and `register_stellar_asset_contract()`
- Removed sdk 21+ shorthands (`register`, `_v2` variants)

 Security
- `require_auth()` on all state-changing functions
- Checks-effects-interactions pattern in `withdraw_stake`
- Amount validation (> 0) enforced

 Testing
- All functions covered
- `mock_all_auths()` applied correctly
- Unauthorized access rejection tested

Closes #259