### PR TITLE
Issue #284: enforce strict price-manager vs network-coordinator role …

### DIFF
--- a/contracts/price-oracle/src/auth.rs
+++ b/contracts/price-oracle/src/auth.rs
@@ -150,6 +150,33 @@ pub fn _require_provider(env: &Env, caller: &Address) {
     }
 }
 
+/// Returns true when the caller is authorized as a dedicated price manager.
+///
+/// This separates everyday price submission rights from high-impact admin
+/// / multi-sig coordinator permissions.
+pub fn _is_price_manager(env: &Env, caller: &Address) -> bool {
+    _is_provider(env, caller)
+}
+
+/// Panics if the caller is not authorized as a dedicated price manager.
+pub fn _require_price_manager(env: &Env, caller: &Address) {
+    if !_is_price_manager(env, caller) {
+        panic!("Unauthorised: caller is not a price manager");
+    }
+}
+
+/// Returns true when the caller is an authorized network coordinator.
+pub fn _is_network_coordinator(env: &Env, caller: &Address) -> bool {
+    _is_authorized(env, caller)
+}
+
+/// Panics if the caller is not an authorized network coordinator.
+pub fn _require_network_coordinator(env: &Env, caller: &Address) {
+    if !_is_network_coordinator(env, caller) {
+        panic!("Unauthorised: caller is not a network coordinator");
+    }
+}
+
 pub fn _set_provider_weight(env: &Env, provider: &Address, weight: u32) {
     env.storage()
         .instance()

--- a/contracts/price-oracle/src/lib.rs
+++ b/contracts/price-oracle/src/lib.rs
@@ -1164,10 +1164,10 @@ impl PriceOracle {
             .ok_or(Error::AssetNotFound)
     }
 
-    /// Set the price data for a specific asset (admin/internal use).
+    /// Set the price data for a specific asset.
     ///
-    /// Writes to the `VerifiedPrice` bucket. Community submissions must use
-    /// `submit_community_price` instead.
+    /// Only whitelisted price managers may submit verified price updates.
+    /// Community submissions must use `submit_community_price` instead.
     ///
     /// # Gas optimisation — Zero-Write for identical prices
     /// When the incoming `val` is identical to the currently stored price the
@@ -1181,6 +1181,12 @@ impl PriceOracle {
     pub fn set_price(env: Env, asset: Symbol, val: i128, decimals: u32, ttl: u64) {
         _require_not_destroyed(&env);
         crate::auth::_require_not_frozen(&env);
+
+        let source = env.invoker();
+        source.require_auth();
+        if source != env.current_contract_address() {
+            crate::auth::_require_price_manager(&env, &source);
+        }
 
         // Acquire reentrancy lock
         if let Err(err) = acquire_lock(&env) {
@@ -1235,7 +1241,7 @@ impl PriceOracle {
             let price_data = PriceData {
                 price: normalized,
                 timestamp: now,
-                provider: env.current_contract_address(),
+                provider: source.clone(),
                 // All stored prices are 9-decimal normalized.
                 decimals: 9,
                 confidence_score: 100,
@@ -1273,7 +1279,7 @@ impl PriceOracle {
                 asset: asset.clone(),
                 price: normalized,
                 timestamp: now,
-                provider: env.current_contract_address(),
+                provider: source.clone(),
                 decimals: 9,
                 confidence_score: 100,
             };

--- a/contracts/price-oracle/src/types.rs
+++ b/contracts/price-oracle/src/types.rs
@@ -28,7 +28,7 @@ pub enum DataKey {
     Initialized,
     /// TWAP Buffer: Stores last 10 (Timestamp, Price) updates.
     Twap(Symbol),
-    /// Verified price bucket: written only by whitelisted providers / admins.
+    /// Verified price bucket: written only by whitelisted price managers.
     /// Internal math and `get_price` default to this bucket.
     VerifiedPrice(Symbol),
     /// Community price bucket: written by any caller; never used in internal math.


### PR DESCRIPTION
…separation in price oracle
Closes #284 


Summary
This PR implements strict administrative boundary isolation for the contracts/price-oracle contract as required by issue #284.

What changed
Added explicit role separation between:
[price managers](vscode-file://vscode-app/c:/Users/USER/AppData/Local/Programs/Microsoft%20VS%20Code/f6cfa2ea24/resources/app/out/vs/code/electron-browser/workbench/workbench.html) (whitelisted providers allowed to submit verified prices)
network coordinators (authorized admins handling multisig/high-impact operations)
Updated [set_price](vscode-file://vscode-app/c:/Users/USER/AppData/Local/Programs/Microsoft%20VS%20Code/f6cfa2ea24/resources/app/out/vs/code/electron-browser/workbench/workbench.html) authorization so only dedicated price managers can submit verified price updates from external callers.
Preserved internal contract self-calls while enforcing provider-based authorization for external invokers.
Updated stored price metadata to record the actual submitting provider rather than always using the contract address.
Clarified contract storage comments to reflect the new dedicated price manager role.

Files changed
contracts/price-oracle/src/auth.rs
contracts/price-oracle/src/lib.rs
contracts/price-oracle/src/types.rs
