### PR TITLE
feat(price-oracle): enforce max age limit on rate map structures

### DIFF
--- a/contracts/price-oracle/src/lib.rs
+++ b/contracts/price-oracle/src/lib.rs
@@ -291,6 +291,14 @@ pub trait TokenContractTrait {
 /// This value is used when no configurable max deviation percentage has been set.
 const MAX_PERCENT_CHANGE_BPS: i128 = 1_000;
 
+/// Maximum age (in seconds) for a rate map entry before consumer reads are rejected.
+///
+/// 60 ledgers × ~5 s/ledger = 300 s ≈ 5 minutes.  Any `PriceData` whose
+/// `timestamp` is older than this boundary causes `get_price` / `get_last_price`
+/// to panic with `Error::StaleRateData`, protecting downstream protocols from
+/// acting on prices that were calculated during a relayer outage.
+pub const MAX_RATE_AGE_SECONDS: u64 = 300;
+
 /// Percentage move threshold (5% = 500 basis points) above which a "cross_call"
 /// volatility event is published so downstream contracts (e.g. liquidation bots)
 /// can react without polling.
@@ -349,6 +357,12 @@ pub enum Error {
     NoPreviousConfig = 23,
     /// Contract has not been initialized yet.
     NotInitialized = 24,
+    /// Rate map entry exceeds the maximum allowed age (MAX_RATE_AGE_SECONDS).
+    ///
+    /// Raised by `get_price` and `get_last_price` when the stored timestamp is
+    /// older than `current_timestamp - MAX_RATE_AGE_SECONDS`, indicating the
+    /// relayer has not refreshed the price within the permitted window.
+    StaleRateData = 25,
 }
 
 #[contract]
@@ -479,6 +493,23 @@ fn _require_initialized(env: &Env) {
 /// `true` if the price is stale (expired), `false` otherwise
 pub fn is_stale(current_time: u64, stored_timestamp: u64, ttl: u64) -> bool {
     current_time >= stored_timestamp.saturating_add(ttl)
+}
+
+/// Panic with `Error::StaleRateData` if the rate map entry has exceeded the
+/// maximum allowed age (`MAX_RATE_AGE_SECONDS`).
+///
+/// This guard is applied on every consumer read (`get_price`, `get_last_price`)
+/// to ensure downstream protocols never act on prices that were calculated
+/// during a relayer connectivity outage.
+///
+/// # Arguments
+/// * `env` - The contract environment (used for `panic_with_error!`)
+/// * `current_time` - The current ledger timestamp
+/// * `stored_timestamp` - The `timestamp` field of the `PriceData` entry
+pub fn enforce_rate_map_max_age(env: &Env, current_time: u64, stored_timestamp: u64) {
+    if current_time > stored_timestamp.saturating_add(MAX_RATE_AGE_SECONDS) {
+        panic_with_error!(env, Error::StaleRateData);
+    }
 }
 
 /// Acquire the reentrancy lock for set_price.
@@ -1010,6 +1041,8 @@ impl PriceOracle {
         match env.storage().persistent().get::<DataKey, PriceData>(&key) {
             Some(price_data) => {
                 let now = env.ledger().timestamp();
+                // Issue #262: panic if the rate map entry exceeds the hard maximum age.
+                enforce_rate_map_max_age(&env, now, price_data.timestamp);
                 if is_stale(now, price_data.timestamp, price_data.ttl) {
                     return Err(Error::AssetNotFound);
                 }

--- a/contracts/price-oracle/src/test.rs
+++ b/contracts/price-oracle/src/test.rs
@@ -2774,3 +2774,87 @@ fn test_enable_bypass_requires_admin() {
     // non_admin is not in the admin list — should panic.
     client.enable_bypass_safety_checks(&non_admin);
 }
+
+// ── Issue #262: rate-map max-age enforcement ─────────────────────────────────
+
+/// `get_price` must succeed when the stored timestamp is within MAX_RATE_AGE_SECONDS.
+#[test]
+fn test_get_price_within_max_age_succeeds() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register(PriceOracle, ());
+    let client = PriceOracleClient::new(&env, &contract_id);
+
+    let asset = symbol_short!("NGN");
+    // Store price at t=1_000.
+    env.ledger().set_timestamp(1_000);
+    env.ledger().set_sequence_number(1);
+    client.set_price(&asset, &1_500_i128, &2u32, &86_400u64);
+
+    // Advance to t=1_299 — still within the 300-second boundary.
+    env.ledger().set_timestamp(1_299);
+    let result = client.try_get_price(&asset, &true);
+    assert!(result.is_ok(), "expected Ok within max age window");
+}
+
+/// `get_price` must panic with `StaleRateData` when the stored timestamp is
+/// older than `current_time - MAX_RATE_AGE_SECONDS` (300 s).
+#[test]
+#[should_panic]
+fn test_get_price_panics_when_rate_map_exceeds_max_age() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register(PriceOracle, ());
+    let client = PriceOracleClient::new(&env, &contract_id);
+
+    let asset = symbol_short!("NGN");
+    // Store price at t=1_000.
+    env.ledger().set_timestamp(1_000);
+    env.ledger().set_sequence_number(1);
+    client.set_price(&asset, &1_500_i128, &2u32, &86_400u64);
+
+    // Advance past the 300-second boundary: t=1_000 + 300 + 1 = 1_301.
+    env.ledger().set_timestamp(1_301);
+    // This must panic with Error::StaleRateData (error code 25).
+    let _ = client.get_price(&asset, &true);
+}
+
+/// `get_last_price` must also panic when the rate map entry is too old,
+/// because it delegates to `get_price`.
+#[test]
+#[should_panic]
+fn test_get_last_price_panics_when_rate_map_exceeds_max_age() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register(PriceOracle, ());
+    let client = PriceOracleClient::new(&env, &contract_id);
+
+    let asset = symbol_short!("KES");
+    env.ledger().set_timestamp(2_000);
+    env.ledger().set_sequence_number(1);
+    client.set_price(&asset, &500_i128, &2u32, &86_400u64);
+
+    // Advance 301 seconds past the stored timestamp.
+    env.ledger().set_timestamp(2_301);
+    let _ = client.get_last_price(&asset);
+}
+
+/// Exactly at the boundary (current_time == stored_timestamp + MAX_RATE_AGE_SECONDS)
+/// the guard must NOT panic — the boundary is exclusive.
+#[test]
+fn test_get_price_at_exact_boundary_does_not_panic() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register(PriceOracle, ());
+    let client = PriceOracleClient::new(&env, &contract_id);
+
+    let asset = symbol_short!("GHS");
+    env.ledger().set_timestamp(5_000);
+    env.ledger().set_sequence_number(1);
+    client.set_price(&asset, &800_i128, &2u32, &86_400u64);
+
+    // Exactly at boundary: 5_000 + 300 = 5_300.
+    env.ledger().set_timestamp(5_300);
+    let result = client.try_get_price(&asset, &true);
+    assert!(result.is_ok(), "expected Ok at exact boundary");
+}


### PR DESCRIPTION
Add MAX_RATE_AGE_SECONDS (300 s ≈ 60 ledgers) constant and a new StaleRateData (error 25) variant.  Introduce enforce_rate_map_max_age helper that panics when current_time > stored_timestamp + 300.

Apply the guard inside get_price so any consumer read (including get_last_price which delegates to get_price) panics immediately when the rate map entry is too old, preventing downstream protocols from acting on stale prices during relayer outages.

Add four tests covering: within-window success, panic past boundary for get_price, panic past boundary for get_last_price, and exact- boundary no-panic.

Closes #262
Closes #273 
Closes #301
Closes #261 