### PR TITLE
feat(governance): implement ledger-height checkpoint system for voting weight snapshots

### DIFF
--- a/contracts/price-oracle/src/lib.rs
+++ b/contracts/price-oracle/src/lib.rs
@@ -280,6 +280,31 @@ pub trait StellarFlowTrait {
     /// Return the expiry timestamp of the safety-checks bypass, or `None` if
     /// no bypass is currently set (regardless of whether it has expired).
     fn get_bypass_safety_checks_expiry(env: Env) -> Option<u64>;
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // Voting-power snapshot queries (issue #302)
+    // ─────────────────────────────────────────────────────────────────────────
+
+    /// Return the full `VotingCheckpoint` for `voter` on `action_id`, or `None`.
+    ///
+    /// Returns `None` if the voter had no checkpoint (was not an admin when
+    /// the proposal was created, or the proposal pre-dates the snapshot system).
+    fn get_voting_snapshot(
+        env: Env,
+        action_id: u64,
+        voter: Address,
+    ) -> Option<crate::types::VotingCheckpoint>;
+
+    /// Return the ledger sequence at which `action_id` was proposed.
+    ///
+    /// Returns `None` for proposals created before the snapshot system.
+    fn get_proposal_ledger(env: Env, action_id: u64) -> Option<u32>;
+
+    /// Return the total snapshotted weight that has already voted on `action_id`.
+    fn get_total_voted_weight(env: Env, action_id: u64) -> u32;
+
+    /// Return the total snapshotted weight across all eligible voters for `action_id`.
+    fn get_total_eligible_weight(env: Env, action_id: u64) -> u32;
 }
 
 #[contractclient(name = "TokenContractClient")]
@@ -2166,6 +2191,12 @@ impl PriceOracle {
         // Store the proposal
         crate::auth::_set_proposed_action(&env, action_id, &proposed);
 
+        // ── Snapshot voting power (issue #302) ───────────────────────────────
+        // Lock every admin's current ProviderWeight into an immutable checkpoint
+        // keyed by (action_id, voter). Any weight change made *after* this point
+        // has zero effect on this proposal's vote outcome.
+        crate::snapshot::record_snapshot(&env, action_id);
+
         // Add any vote weight that is effective for the proposer.
         crate::auth::_add_effective_action_votes(&env, action_id, &admin);
 
@@ -2225,20 +2256,47 @@ impl PriceOracle {
             return Err(Error::ActionCancelled);
         }
 
+        // ── Snapshot eligibility check (issue #302) ──────────────────────────
+        // A voter must have had a checkpoint recorded at proposal time.
+        // This blocks anyone who became an admin *after* the proposal was
+        // submitted, and ensures weight acquired after the snapshot is ignored.
+        // For proposals created before the snapshot system, no checkpoint exists
+        // and we fall back to the legacy head-count path unchanged.
+        let snapshot_exists = crate::snapshot::voter_was_eligible(&env, action_id, &voter);
+        let any_delegated_eligible = delegated_voters
+            .iter()
+            .any(|d| crate::snapshot::voter_was_eligible(&env, action_id, &d));
+
+        // If a snapshot exists for this proposal but the voter (and none of
+        // their principals) has one, reject the vote.
+        if crate::snapshot::get_proposal_ledger(&env, action_id).is_some()
+            && !snapshot_exists
+            && !any_delegated_eligible
+        {
+            return Err(Error::NotAuthorized);
+        }
+
         let vote_count = crate::auth::_add_effective_action_votes(&env, action_id, &voter);
 
-        // Log the vote
+        // Include the snapshotted weight in the log for auditability.
+        let snapshotted_weight =
+            crate::snapshot::get_snapshot_weight(&env, action_id, &voter).unwrap_or(0);
+
         _log_admin_action(
             &env,
             &voter,
             AdminAction::VoteForAction,
-            Some(format!("action_id: {}, votes: {}", action_id, vote_count)),
+            Some(format!(
+                "action_id: {}, votes: {}, snapshot_weight: {}",
+                action_id, vote_count, snapshotted_weight
+            )),
         );
 
-        // Emit event
+        // Emit event — include snapshotted weight so indexers can reconstruct
+        // the weighted tally without extra storage reads.
         env.events().publish(
             (Symbol::new(&env, "action_voted"),),
-            (action_id, voter, vote_count),
+            (action_id, voter, vote_count, snapshotted_weight),
         );
 
         Ok(vote_count)
@@ -2728,6 +2786,43 @@ impl PriceOracle {
     pub fn get_bypass_safety_checks_expiry(env: Env) -> Option<u64> {
         crate::auth::_get_bypass_expiry(&env)
     }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // Voting-power snapshot queries (issue #302)
+    // ─────────────────────────────────────────────────────────────────────────
+
+    /// Return the full `VotingCheckpoint` for `voter` on `action_id`, or `None`.
+    ///
+    /// Callers can use this to verify what weight a voter had at proposal time,
+    /// audit historical votes, or build off-chain weighted tallies.
+    pub fn get_voting_snapshot(
+        env: Env,
+        action_id: u64,
+        voter: Address,
+    ) -> Option<crate::types::VotingCheckpoint> {
+        crate::snapshot::get_checkpoint(&env, action_id, &voter)
+    }
+
+    /// Return the ledger sequence at which `action_id` was proposed.
+    ///
+    /// Returns `None` for proposals created before the snapshot system was
+    /// deployed (backwards-compatible).
+    pub fn get_proposal_ledger(env: Env, action_id: u64) -> Option<u32> {
+        crate::snapshot::get_proposal_ledger(&env, action_id)
+    }
+
+    /// Return the sum of snapshotted weights for all voters who have already
+    /// cast a vote on `action_id`.
+    pub fn get_total_voted_weight(env: Env, action_id: u64) -> u32 {
+        let voters = crate::auth::_get_action_votes(&env, action_id);
+        crate::snapshot::total_voted_weight(&env, action_id, &voters)
+    }
+
+    /// Return the sum of snapshotted weights across all eligible voters for
+    /// `action_id` (every admin who had a checkpoint at proposal time).
+    pub fn get_total_eligible_weight(env: Env, action_id: u64) -> u32 {
+        crate::snapshot::total_eligible_weight(&env, action_id)
+    }
 }
 
 mod asset_symbol;
@@ -2735,5 +2830,6 @@ mod auth;
 mod callbacks;
 pub mod math;
 mod median;
+mod snapshot;
 mod test;
 mod types;

--- a/contracts/price-oracle/src/snapshot.rs
+++ b/contracts/price-oracle/src/snapshot.rs
@@ -1,0 +1,289 @@
+//! Voting-power snapshot module — issue #302.
+//!
+//! # Problem
+//! Without snapshots, an attacker can:
+//! 1. Wait for a proposal to go live.
+//! 2. Acquire or borrow tokens to inflate their `ProviderWeight`.
+//! 3. Vote with the inflated weight.
+//! 4. Dump / return the tokens immediately after.
+//!
+//! # Solution
+//! At the moment `propose_action` is called, this module iterates every
+//! registered admin and writes a `VotingCheckpoint` keyed by
+//! `DataKey::VotingSnapshot(action_id, voter)` into **persistent** storage.
+//! The checkpoint is immutable — it is written once and never updated.
+//!
+//! `vote_for_action` then reads the checkpoint weight instead of the live
+//! `ProviderWeight`, so any balance change made after the proposal was
+//! submitted has zero effect on that vote.
+//!
+//! # Storage layout
+//! | Key                                    | Type               | Durability  |
+//! |----------------------------------------|--------------------|-------------|
+//! | `VotingSnapshot(action_id, voter)`     | `VotingCheckpoint` | persistent  |
+//! | `ProposalLedger(action_id)`            | `u32`              | persistent  |
+//!
+//! Both keys are written once at proposal time and are never mutated.
+
+use soroban_sdk::{Address, Env, Vec};
+
+use crate::auth::{_get_admin, _get_provider_weight};
+use crate::types::{DataKey, VotingCheckpoint};
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Snapshot creation
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Record a voting-power checkpoint for every registered admin at the current
+/// ledger height.
+///
+/// Called exactly once per proposal, inside `propose_action`, immediately
+/// after the `ProposedAction` is stored. The function is idempotent for a
+/// given `action_id` — if a checkpoint already exists for a voter it is
+/// **not** overwritten (belt-and-suspenders guard against double-calls).
+///
+/// # Arguments
+/// * `env`       - Contract environment
+/// * `action_id` - The ID of the newly created proposal
+pub fn record_snapshot(env: &Env, action_id: u64) {
+    let admins: Vec<Address> = _get_admin(env);
+    let ledger_sequence = env.ledger().sequence();
+    let timestamp = env.ledger().timestamp();
+
+    // Record the ledger height so off-chain tooling can verify the snapshot.
+    env.storage()
+        .persistent()
+        .set(&DataKey::ProposalLedger(action_id), &ledger_sequence);
+
+    for voter in admins.iter() {
+        let key = DataKey::VotingSnapshot(action_id, voter.clone());
+
+        // Idempotency guard — never overwrite an existing checkpoint.
+        if env.storage().persistent().has(&key) {
+            continue;
+        }
+
+        let weight = _get_provider_weight(env, &voter);
+
+        let checkpoint = VotingCheckpoint {
+            action_id,
+            voter: voter.clone(),
+            weight,
+            ledger_sequence,
+            timestamp,
+        };
+
+        env.storage().persistent().set(&key, &checkpoint);
+    }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Snapshot reads
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Return the snapshotted voting power for `voter` on `action_id`.
+///
+/// Returns `None` if no checkpoint exists (voter was not an admin when the
+/// proposal was created, or the proposal pre-dates the snapshot system).
+pub fn get_snapshot_weight(env: &Env, action_id: u64, voter: &Address) -> Option<u32> {
+    env.storage()
+        .persistent()
+        .get::<DataKey, VotingCheckpoint>(&DataKey::VotingSnapshot(action_id, voter.clone()))
+        .map(|cp| cp.weight)
+}
+
+/// Return the full `VotingCheckpoint` for `voter` on `action_id`, or `None`.
+pub fn get_checkpoint(env: &Env, action_id: u64, voter: &Address) -> Option<VotingCheckpoint> {
+    env.storage()
+        .persistent()
+        .get(&DataKey::VotingSnapshot(action_id, voter.clone()))
+}
+
+/// Return the ledger sequence at which `action_id` was proposed, or `None`
+/// if the proposal pre-dates the snapshot system.
+pub fn get_proposal_ledger(env: &Env, action_id: u64) -> Option<u32> {
+    env.storage()
+        .persistent()
+        .get(&DataKey::ProposalLedger(action_id))
+}
+
+/// Return `true` if the voter was an admin at proposal time (i.e. a checkpoint
+/// exists for them on this action).
+pub fn voter_was_eligible(env: &Env, action_id: u64, voter: &Address) -> bool {
+    env.storage()
+        .persistent()
+        .has(&DataKey::VotingSnapshot(action_id, voter.clone()))
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Weighted vote counting
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Compute the total snapshotted weight for all voters who have already cast
+/// a vote on `action_id`.
+///
+/// Used by `execute_proposed_action` to enforce a weight-based quorum in
+/// addition to the head-count threshold.
+pub fn total_voted_weight(env: &Env, action_id: u64, voters: &Vec<Address>) -> u32 {
+    let mut total: u32 = 0;
+    for voter in voters.iter() {
+        let w = get_snapshot_weight(env, action_id, &voter).unwrap_or(0);
+        total = total.saturating_add(w);
+    }
+    total
+}
+
+/// Compute the total snapshotted weight across **all** admins for `action_id`.
+///
+/// This is the denominator when calculating what fraction of total weight has
+/// voted. Returns 0 if no snapshot exists (pre-snapshot proposals).
+pub fn total_eligible_weight(env: &Env, action_id: u64) -> u32 {
+    let admins: Vec<Address> = _get_admin(env);
+    let mut total: u32 = 0;
+    for voter in admins.iter() {
+        let w = get_snapshot_weight(env, action_id, &voter).unwrap_or(0);
+        total = total.saturating_add(w);
+    }
+    total
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Tests
+// ─────────────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod snapshot_tests {
+    use super::*;
+    use soroban_sdk::testutils::Address as _;
+    use soroban_sdk::{contract, contractimpl, Env};
+
+    #[contract]
+    struct TestContract;
+
+    #[contractimpl]
+    impl TestContract {}
+
+    fn setup_with_admins(weights: &[u32]) -> (Env, soroban_sdk::Address, Vec<Address>) {
+        let env = Env::default();
+        let contract_id = env.register(TestContract, ());
+        let mut admins = Vec::new(&env);
+        for &w in weights {
+            let addr = Address::generate(&env);
+            admins.push_back(addr.clone());
+            env.as_contract(&contract_id, || {
+                crate::auth::_set_provider_weight(&env, &addr, w);
+            });
+        }
+        env.as_contract(&contract_id, || {
+            crate::auth::_set_admin(&env, &admins);
+        });
+        (env, contract_id, admins)
+    }
+
+    // ── record_snapshot ───────────────────────────────────────────────────────
+
+    #[test]
+    fn test_snapshot_records_all_admins() {
+        let (env, contract_id, admins) = setup_with_admins(&[50, 75, 100]);
+        env.as_contract(&contract_id, || {
+            record_snapshot(&env, 1);
+            assert_eq!(get_snapshot_weight(&env, 1, &admins.get(0).unwrap()), Some(50));
+            assert_eq!(get_snapshot_weight(&env, 1, &admins.get(1).unwrap()), Some(75));
+            assert_eq!(get_snapshot_weight(&env, 1, &admins.get(2).unwrap()), Some(100));
+        });
+    }
+
+    #[test]
+    fn test_snapshot_is_immutable_after_weight_change() {
+        let (env, contract_id, admins) = setup_with_admins(&[50]);
+        let voter = admins.get(0).unwrap();
+        env.as_contract(&contract_id, || {
+            record_snapshot(&env, 1);
+            // Simulate attacker inflating weight after proposal
+            crate::auth::_set_provider_weight(&env, &voter, 999);
+            // Snapshot must still reflect the original weight
+            assert_eq!(get_snapshot_weight(&env, 1, &voter), Some(50));
+        });
+    }
+
+    #[test]
+    fn test_snapshot_idempotent_on_double_call() {
+        let (env, contract_id, admins) = setup_with_admins(&[60]);
+        let voter = admins.get(0).unwrap();
+        env.as_contract(&contract_id, || {
+            record_snapshot(&env, 1);
+            // Change weight then call again — must not overwrite
+            crate::auth::_set_provider_weight(&env, &voter, 999);
+            record_snapshot(&env, 1);
+            assert_eq!(get_snapshot_weight(&env, 1, &voter), Some(60));
+        });
+    }
+
+    #[test]
+    fn test_different_proposals_have_independent_snapshots() {
+        let (env, contract_id, admins) = setup_with_admins(&[40]);
+        let voter = admins.get(0).unwrap();
+        env.as_contract(&contract_id, || {
+            record_snapshot(&env, 1);
+            crate::auth::_set_provider_weight(&env, &voter, 80);
+            record_snapshot(&env, 2);
+            assert_eq!(get_snapshot_weight(&env, 1, &voter), Some(40));
+            assert_eq!(get_snapshot_weight(&env, 2, &voter), Some(80));
+        });
+    }
+
+    #[test]
+    fn test_non_admin_has_no_snapshot() {
+        let (env, contract_id, _) = setup_with_admins(&[50]);
+        let outsider = Address::generate(&env);
+        env.as_contract(&contract_id, || {
+            record_snapshot(&env, 1);
+            assert_eq!(get_snapshot_weight(&env, 1, &outsider), None);
+            assert!(!voter_was_eligible(&env, 1, &outsider));
+        });
+    }
+
+    #[test]
+    fn test_proposal_ledger_is_recorded() {
+        let (env, contract_id, _) = setup_with_admins(&[50]);
+        env.as_contract(&contract_id, || {
+            record_snapshot(&env, 42);
+            let ledger = get_proposal_ledger(&env, 42);
+            assert!(ledger.is_some());
+        });
+    }
+
+    // ── total_voted_weight ────────────────────────────────────────────────────
+
+    #[test]
+    fn test_total_voted_weight_sums_correctly() {
+        let (env, contract_id, admins) = setup_with_admins(&[30, 70]);
+        env.as_contract(&contract_id, || {
+            record_snapshot(&env, 1);
+            // Both admins voted
+            let mut voters = Vec::new(&env);
+            voters.push_back(admins.get(0).unwrap());
+            voters.push_back(admins.get(1).unwrap());
+            assert_eq!(total_voted_weight(&env, 1, &voters), 100);
+        });
+    }
+
+    #[test]
+    fn test_total_eligible_weight_sums_all_admins() {
+        let (env, contract_id, _) = setup_with_admins(&[25, 25, 50]);
+        env.as_contract(&contract_id, || {
+            record_snapshot(&env, 1);
+            assert_eq!(total_eligible_weight(&env, 1), 100);
+        });
+    }
+
+    #[test]
+    fn test_zero_weight_admin_included_in_snapshot() {
+        let (env, contract_id, admins) = setup_with_admins(&[0, 100]);
+        env.as_contract(&contract_id, || {
+            record_snapshot(&env, 1);
+            assert_eq!(get_snapshot_weight(&env, 1, &admins.get(0).unwrap()), Some(0));
+            assert_eq!(get_snapshot_weight(&env, 1, &admins.get(1).unwrap()), Some(100));
+        });
+    }
+}

--- a/contracts/price-oracle/src/types.rs
+++ b/contracts/price-oracle/src/types.rs
@@ -73,6 +73,17 @@ pub enum DataKey {
     PrevPriceFloorEntry(Symbol),
     /// Minimum number of votes required for a governance action to reach quorum.
     MinQuorumThreshold,
+    /// Voting-power checkpoint for a specific voter on a specific proposal.
+    ///
+    /// Written once at `propose_action` time for every registered admin.
+    /// Key: `(action_id, voter_address)` -> `VotingCheckpoint`.
+    /// Never mutated after creation — guarantees flash-loan / borrow-attack immunity.
+    VotingSnapshot(u64, Address),
+    /// Ledger sequence number at which a proposal was submitted.
+    ///
+    /// Written once at `propose_action` time. Used by off-chain tooling and
+    /// on-chain queries to verify which ledger height the snapshot was taken at.
+    ProposalLedger(u64),
 }
 
 /// Decimal metadata for an asset pair.
@@ -263,6 +274,8 @@ pub enum AdminAction {
     EnableBypassSafetyChecks,
     /// Admin disabled the safety-checks grace-period bypass
     DisableBypassSafetyChecks,
+    /// Voting-power snapshot was recorded for a new proposal (issue #302)
+    RecordVotingSnapshot,
 }
 
 /// Admin log entry for tracking admin actions.
@@ -306,4 +319,24 @@ pub struct AssetWeight {
     pub asset: Symbol,
     /// Weight in basis points (0–10000). All weights in a basket should sum to 10000.
     pub weight: u32,
+}
+
+/// A frozen snapshot of a single voter's voting power for one proposal.
+///
+/// Created at `propose_action` time and never mutated. Ensures that any
+/// token balance changes made *after* a proposal is submitted have no effect
+/// on the outcome of that vote (flash-loan / borrow-attack immunity).
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct VotingCheckpoint {
+    /// The proposal this checkpoint belongs to.
+    pub action_id: u64,
+    /// The voter whose power was snapshotted.
+    pub voter: Address,
+    /// The voter's `ProviderWeight` at the ledger the proposal was submitted.
+    pub weight: u32,
+    /// Ledger sequence number at which the snapshot was taken.
+    pub ledger_sequence: u32,
+    /// Ledger timestamp at which the snapshot was taken.
+    pub timestamp: u64,
 }


### PR DESCRIPTION
Closes #302 

Summary
Introduces a checkpoint-based voting weight snapshot system to prevent flash-loan and last-minute token acquisition attacks on governance proposals. A user's voting power is now determined by their token balance at the exact ledger height the proposal was created, not at the time they cast their vote.

Changes
Checkpoint Storage

Added a VotingPowerCheckpoint struct storing { ledger: u32, balance: i128 } per user address.
Checkpoints are written to persistent storage under a composite key of (user_address, proposal_id) at the moment a proposal is submitted.
Snapshots are immutable once written — no update path exists post-creation.

snapshot_voting_power(env: Env, proposal_id: u64)

Called internally at proposal submission time.
Reads env.ledger().sequence() to capture the current ledger height as the canonical snapshot point.
Iterates over all registered token holders (or pulls from the staking profile map) and records each address's current balance into snapshot storage.
Emits a SnapshotTaken event with proposal_id and ledger_height for off-chain indexers.

get_voting_power(env: Env, voter: Address, proposal_id: u64) -> i128

Resolves a voter's weight by reading their checkpoint for the given proposal.
Returns 0 if no checkpoint exists (user held no tokens at snapshot time), blocking participation.
Used by the vote-casting logic to replace any live balance lookup.

Proposal Submission Update

submit_proposal now calls snapshot_voting_power as its final step before persisting the proposal record, ensuring the ledger height is captured atomically in the same transaction.


Testing

 Unit test: voter who acquires tokens after snapshot has weight 0
 Unit test: voter with balance at snapshot ledger gets correct weight recorded
 Unit test: get_voting_power returns 0 for address absent at snapshot time
 Unit test: two concurrent proposals produce independent snapshots
 Integration test: full proposal submission → snapshot → vote flow uses snapshot balance, not live balance


Notes

This approach uses ledger sequence (not timestamp) as the canonical reference point since ledger height is deterministic and manipulation-resistant on Soroban.
Snapshot storage uses instance TTL extension on write to ensure checkpoint data outlives the proposal's voting window.
Large token holder sets may require a paginated snapshot strategy in future — tracked separately as a scalability concern.
