### PR TITLE
feat: implement exponential moving average for analytics engine #349

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,6 +18,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
+name = "analytics-engine"
+version = "0.0.0"
+dependencies = [
+ "soroban-sdk",
+]
+
+[[package]]
 name = "android_system_properties"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -824,6 +831,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
  "getrandom",
+]
+
+[[package]]
+name = "reward-splitter"
+version = "0.0.0"
+dependencies = [
+ "soroban-sdk",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ description = "StellarFlow smart contracts with time-locked upgrade mechanism"
 
 [workspace]
 members = [
+    "contracts/analytics-engine",
     "contracts/hello-world",
     "contracts/ledger-time-helper",
     "contracts/price-oracle",

--- a/contracts/analytics-engine/Cargo.toml
+++ b/contracts/analytics-engine/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "analytics-engine"
+version = "0.0.0"
+edition = "2021"
+publish = false
+
+[lib]
+crate-type = ["cdylib", "rlib"]
+doctest = false
+
+[dependencies]
+soroban-sdk = { workspace = true }
+
+[dev-dependencies]
+soroban-sdk = { workspace = true, features = ["testutils"] }

--- a/contracts/analytics-engine/src/lib.rs
+++ b/contracts/analytics-engine/src/lib.rs
@@ -1,0 +1,71 @@
+#![no_std]
+
+use soroban_sdk::{contract, contractimpl, contracttype, Env, Symbol};
+
+const ALPHA_SCALE: i128 = 10_000;
+
+#[derive(Clone)]
+#[contracttype]
+pub enum DataKey {
+    EmaRecord(Symbol), // Maps an asset symbol to its EMA
+    Alpha,             // The smoothing factor
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+#[contracttype]
+pub struct EmaRecord {
+    pub value: i128,
+    pub last_updated: u64,
+}
+
+#[contract]
+pub struct AnalyticsEngine;
+
+#[contractimpl]
+impl AnalyticsEngine {
+    pub fn initialize(env: Env, alpha: i128) {
+        if env.storage().instance().has(&DataKey::Alpha) {
+            panic!("already initialized");
+        }
+        if alpha <= 0 || alpha > ALPHA_SCALE {
+            panic!("invalid alpha");
+        }
+        env.storage().instance().set(&DataKey::Alpha, &alpha);
+    }
+
+    /// Implement an optimized calculation method that updates a single, rolling smoothing metric upon every new price submission.
+    /// Store only the finalized moving average record in persistent data slots to minimize long-term storage rent fees.
+    pub fn submit_price(env: Env, asset: Symbol, price: i128) {
+        if price <= 0 {
+            panic!("price must be positive");
+        }
+        
+        let alpha: i128 = env.storage().instance().get(&DataKey::Alpha).unwrap_or_else(|| panic!("not initialized"));
+        let key = DataKey::EmaRecord(asset.clone());
+        
+        let new_ema = if let Some(record) = env.storage().persistent().get::<_, EmaRecord>(&key) {
+            // Calculate new EMA: (Price * alpha + Old_EMA * (1 - alpha))
+            (price * alpha + record.value * (ALPHA_SCALE - alpha)) / ALPHA_SCALE
+        } else {
+            // First price submission becomes the initial EMA
+            price
+        };
+
+        let new_record = EmaRecord {
+            value: new_ema,
+            last_updated: env.ledger().timestamp(),
+        };
+
+        // Store only the finalized moving average record in persistent data slots
+        env.storage().persistent().set(&key, &new_record);
+    }
+
+    pub fn get_ema(env: Env, asset: Symbol) -> i128 {
+        let key = DataKey::EmaRecord(asset);
+        if let Some(record) = env.storage().persistent().get::<_, EmaRecord>(&key) {
+            record.value
+        } else {
+            0
+        }
+    }
+}


### PR DESCRIPTION
- Created the `analytics-engine` contract in the `contracts/` directory and added it to the workspace members.
- Implemented an optimized `submit_price` method that computes the Exponential Moving Average (EMA) using a single, rolling smoothing metric (`alpha`) upon every new price submission.
- Stored only the finalized moving average record (`EmaRecord`) in persistent data slots.
- Added a `get_ema` read function to access the current smoothed average.
**Why it was done:**
Tracking historical mathematical averages by loading entire price histories strains on-chain storage limits and increases execution cost. This optimized EMA calculation avoids high rent fees and large ledger state usage by replacing continuous history accumulation with a single rolling state metric.
**How it was verified:**
- Verified that the `analytics-engine` contract correctly leverages `env.storage().persistent().set()` to store the rolling average without accumulating history arrays.
- Ran `cargo check` inside the `analytics-engine` module and verified the build succeeds without any errors.
Closes #349 