### PR TITLE
feat: add sig_expires_at expiry to admin signature packets (#347)

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,6 +25,7 @@ pub enum ContractError {
     NoActiveProposal = 15,
     AlreadyVoted = 16,
     ThresholdNotReached = 17,
+    SignatureExpired = 18,
 }
 
 // Contract state keys
@@ -236,7 +237,11 @@ impl TimeLockedUpgradeContract {
         new_wasm_hash: BytesN<32>,
         proposer: Address,
         nonce: u64,
+        sig_expires_at: u64,
     ) -> Result<(), ContractError> {
+        if env.ledger().timestamp() > sig_expires_at {
+            return Err(ContractError::SignatureExpired);
+        }
         let data = Self::get_data(env.clone())?;
         
         // Only admin can propose upgrades
@@ -259,7 +264,10 @@ impl TimeLockedUpgradeContract {
     }
 
     /// Execute a pending upgrade if the timelock period has passed
-    pub fn execute_upgrade(env: Env, executor: Address, nonce: u64) -> Result<(), ContractError> {
+    pub fn execute_upgrade(env: Env, executor: Address, nonce: u64, sig_expires_at: u64) -> Result<(), ContractError> {
+        if env.ledger().timestamp() > sig_expires_at {
+            return Err(ContractError::SignatureExpired);
+        }
         let data = Self::get_data(env.clone())?;
         
         // Only admin can execute upgrades
@@ -336,7 +344,10 @@ impl TimeLockedUpgradeContract {
     ///
     /// Also records a heartbeat for the implicit "VALUE" asset so that
     /// `is_data_fresh` can track when the last state mutation occurred.
-    pub fn set_value(env: Env, value: u64, setter: Address, nonce: u64) -> Result<(), ContractError> {
+    pub fn set_value(env: Env, value: u64, setter: Address, nonce: u64, sig_expires_at: u64) -> Result<(), ContractError> {
+        if env.ledger().timestamp() > sig_expires_at {
+            return Err(ContractError::SignatureExpired);
+        }
         let mut data = Self::get_data(env.clone())?;
         
         // Only admin can set values
@@ -508,7 +519,11 @@ impl TimeLockedUpgradeContract {
         target: Address,
         replacement: Address,
         proposer: Address,
+        sig_expires_at: u64,
     ) -> Result<(), ContractError> {
+        if env.ledger().timestamp() > sig_expires_at {
+            return Err(ContractError::SignatureExpired);
+        }
         proposer.require_auth();
         let data = Self::get_data(env.clone())?;
 
@@ -540,7 +555,10 @@ impl TimeLockedUpgradeContract {
     ///
     /// When the vote count reaches the majority threshold the admin key is
     /// immediately replaced with `replacement`.
-    pub fn vote_revocation(env: Env, voter: Address) -> Result<(), ContractError> {
+    pub fn vote_revocation(env: Env, voter: Address, sig_expires_at: u64) -> Result<(), ContractError> {
+        if env.ledger().timestamp() > sig_expires_at {
+            return Err(ContractError::SignatureExpired);
+        }
         voter.require_auth();
         let data = Self::get_data(env.clone())?;
 

--- a/src/test.rs
+++ b/src/test.rs
@@ -39,7 +39,7 @@ fn test_initialize_and_basic_functionality() {
     assert_eq!(data.admin, admin);
     assert_eq!(data.value, 0);
 
-    client.set_value(&42, &admin, &0);
+    client.set_value(&42, &admin, &0, &u64::MAX);
     let data = client.get_data();
     assert_eq!(data.value, 42);
 }
@@ -56,7 +56,7 @@ fn test_propose_upgrade() {
 
     let new_wasm_hash = soroban_sdk::BytesN::from_array(&env, &[1u8; 32]);
 
-    client.propose_upgrade(&new_wasm_hash, &admin, &0);
+    client.propose_upgrade(&new_wasm_hash, &admin, &0, &u64::MAX);
 
     let pending = client.get_pending_upgrade();
     assert!(pending.is_some());
@@ -82,7 +82,7 @@ fn test_execute_upgrade_after_timelock() {
 
     let new_wasm_hash = soroban_sdk::BytesN::from_array(&env, &[1u8; 32]);
 
-    client.propose_upgrade(&new_wasm_hash, &admin, &0);
+    client.propose_upgrade(&new_wasm_hash, &admin, &0, &u64::MAX);
 
     // Fast forward time by 48 hours
     advance_ledger_timestamp(&env, UPGRADE_DELAY_SECONDS);
@@ -104,7 +104,7 @@ fn test_cancel_upgrade() {
 
     let new_wasm_hash = soroban_sdk::BytesN::from_array(&env, &[1u8; 32]);
 
-    client.propose_upgrade(&new_wasm_hash, &admin, &0);
+    client.propose_upgrade(&new_wasm_hash, &admin, &0, &u64::MAX);
     assert!(client.get_pending_upgrade().is_some());
 
     client.cancel_upgrade(&admin);
@@ -125,7 +125,7 @@ fn test_timelock_countdown() {
 
     let new_wasm_hash = soroban_sdk::BytesN::from_array(&env, &[1u8; 32]);
 
-    client.propose_upgrade(&new_wasm_hash, &admin, &0);
+    client.propose_upgrade(&new_wasm_hash, &admin, &0, &u64::MAX);
 
     let remaining = client.get_upgrade_timelock_remaining().unwrap();
     assert_eq!(remaining, UPGRADE_DELAY_SECONDS);
@@ -453,7 +453,7 @@ fn test_set_value_updates_heartbeat() {
     assert!(!client.is_data_fresh(&value_asset));
 
     // Call set_value — should auto-record heartbeat
-    client.set_value(&42, &admin, &0);
+    client.set_value(&42, &admin, &0, &u64::MAX);
 
     // Now the "VALUE" asset should have a fresh heartbeat
     assert!(client.is_data_fresh(&value_asset));
@@ -464,7 +464,7 @@ fn test_set_value_updates_heartbeat() {
     assert!(!client.is_data_fresh(&value_asset));
 
     // Another set_value call refreshes the heartbeat
-    client.set_value(&100, &admin, &1);
+    client.set_value(&100, &admin, &1, &u64::MAX);
     assert!(client.is_data_fresh(&value_asset));
 }
 
@@ -493,7 +493,7 @@ fn test_unauthorized_set_value_returns_typed_error() {
     let unauthorized = soroban_sdk::Address::generate(&env);
     client.initialize(&admin);
 
-    let result = client.try_set_value(&42, &unauthorized, &0u64);
+    let result = client.try_set_value(&42, &unauthorized, &0u64, &u64::MAX);
     assert_eq!(result, Err(Ok(ContractError::NotAdmin)));
 }
 
@@ -509,4 +509,26 @@ fn test_zero_heartbeat_interval_returns_typed_error() {
 
     let result = client.try_set_heartbeat_interval(&0, &admin);
     assert_eq!(result, Err(Ok(ContractError::InvalidHeartbeatInterval)));
+}
+
+#[test]
+fn test_expired_signature_rejected() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register_contract(None, TimeLockedUpgradeContract);
+    let client = TimeLockedUpgradeContractClient::new(&env, &contract_id);
+
+    let admin = soroban_sdk::Address::generate(&env);
+    client.initialize(&admin);
+
+    // Advance ledger past the expiry window
+    advance_ledger_timestamp(&env, 1000);
+    let expired_at: u64 = 500; // already in the past
+
+    let new_wasm_hash = soroban_sdk::BytesN::from_array(&env, &[1u8; 32]);
+    let result = client.try_propose_upgrade(&new_wasm_hash, &admin, &0, &expired_at);
+    assert_eq!(result, Err(Ok(ContractError::SignatureExpired)));
+
+    let result = client.try_set_value(&42, &admin, &0, &expired_at);
+    assert_eq!(result, Err(Ok(ContractError::SignatureExpired)));
 }


### PR DESCRIPTION
Closes #347
- Add SignatureExpired error variant to ContractError
- Enforce expiry deadline on propose_upgrade, execute_upgrade, set_value, propose_revocation, and vote_revocation
- Reject payloads where ledger timestamp exceeds sig_expires_at
- Update tests and add test_expired_signature_rejected coverage