### PR TITLE
feat: #264 multisig weight threshold + #263 gas-optimized health slots

### DIFF
--- a/contracts/price-oracle/src/auth.rs
+++ b/contracts/price-oracle/src/auth.rs
@@ -129,6 +129,12 @@ pub fn _add_provider(env: &Env, provider: &Address) {
         .instance()
         .set(&DataKey::Provider(provider.clone()), &true);
     _add_to_active_relayers(env, provider);
+
+    // Issue #263: keep the isolated HealthActiveRelayers slot in sync.
+    let count = _get_active_relayers(env).len();
+    env.storage()
+        .persistent()
+        .set(&crate::types::DataKey::HealthActiveRelayers, &count);
 }
 
 /// Remove a provider from the whitelist.
@@ -137,6 +143,12 @@ pub fn _remove_provider(env: &Env, provider: &Address) {
         .instance()
         .remove(&DataKey::Provider(provider.clone()));
     _remove_from_active_relayers(env, provider);
+
+    // Issue #263: keep the isolated HealthActiveRelayers slot in sync.
+    let count = _get_active_relayers(env).len();
+    env.storage()
+        .persistent()
+        .set(&crate::types::DataKey::HealthActiveRelayers, &count);
 }
 
 /// Returns `true` if the address is a whitelisted provider.
@@ -429,18 +441,61 @@ pub fn _add_action_vote(env: &Env, action_id: u64, voter: &Address) {
 }
 
 /// Check if an action has reached the required threshold (3/5).
+///
+/// # Issue #264 — Weight-accumulation algorithm
+///
+/// Instead of simply counting votes, this function sums the governance weight
+/// of every voter and compares the total against the configured
+/// `WeightThreshold`.  Each admin's weight is stored under
+/// `DataKey::AdminWeight(addr)` and defaults to **1** when unset, so existing
+/// deployments that have never called `set_admin_weight` continue to behave
+/// exactly as before (one vote = one unit of weight).
+///
+/// The `threshold` parameter is the *fallback* vote-count threshold used when
+/// no `WeightThreshold` has been configured.  When a `WeightThreshold` is
+/// present it takes precedence and the raw vote count is ignored.
 pub fn _has_reached_threshold(env: &Env, action_id: u64, threshold: u32) -> bool {
     let voters = _get_action_votes(env, action_id);
-    let admins = _get_admin(env);
-    let admin_count = admins.len() as u32;
 
-    // Threshold is met if we have at least `threshold` votes
-    // Default: 3 out of 5 admins required
-    voters.len() >= threshold
+    // ── Resolve the required weight threshold ────────────────────────────────
+    // If a WeightThreshold has been configured (issue #264) use it; otherwise
+    // fall back to the legacy vote-count threshold so old deployments are
+    // unaffected.
+    let required_weight: u32 = env
+        .storage()
+        .persistent()
+        .get(&crate::types::DataKey::WeightThreshold)
+        .unwrap_or(threshold); // fallback: 1 vote = 1 weight unit
+
+    // ── Accumulate voter weights ─────────────────────────────────────────────
+    let mut accumulated_weight: u32 = 0;
+    for voter in voters.iter() {
+        let weight: u32 = env
+            .storage()
+            .persistent()
+            .get(&crate::types::DataKey::AdminWeight(voter.clone()))
+            .unwrap_or(1); // default weight = 1 (backward-compatible)
+        accumulated_weight = accumulated_weight.saturating_add(weight);
+    }
+
+    accumulated_weight >= required_weight
 }
 
 /// Get the required threshold based on admin count (3/5 of admins).
+///
+/// Returns the *vote-count* threshold used as the fallback when no
+/// `WeightThreshold` has been configured.  When `WeightThreshold` is set,
+/// `_has_reached_threshold` uses that value instead.
 pub fn _get_required_threshold(env: &Env) -> u32 {
+    // If a weight threshold is configured, surface it as the canonical value.
+    if let Some(wt) = env
+        .storage()
+        .persistent()
+        .get::<crate::types::DataKey, u32>(&crate::types::DataKey::WeightThreshold)
+    {
+        return wt;
+    }
+
     let admins = _get_admin(env);
     let admin_count = admins.len() as u32;
 
@@ -453,6 +508,49 @@ pub fn _get_required_threshold(env: &Env) -> u32 {
     } else {
         3 // 3/5 threshold for larger groups
     }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Issue #264: Admin weight helpers
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Set the governance weight for a specific admin (issue #264).
+///
+/// Weight must be in the range 1–100.  A weight of 0 is rejected because a
+/// zero-weight admin could never contribute to reaching the threshold.
+pub fn _set_admin_weight(env: &Env, admin: &Address, weight: u32) {
+    env.storage()
+        .persistent()
+        .set(&crate::types::DataKey::AdminWeight(admin.clone()), &weight);
+}
+
+/// Get the governance weight for a specific admin (issue #264).
+///
+/// Returns 1 (the default) when no weight has been explicitly assigned,
+/// preserving backward compatibility with deployments that predate #264.
+pub fn _get_admin_weight(env: &Env, admin: &Address) -> u32 {
+    env.storage()
+        .persistent()
+        .get(&crate::types::DataKey::AdminWeight(admin.clone()))
+        .unwrap_or(1)
+}
+
+/// Set the minimum cumulative weight required for a governance proposal to
+/// execute (issue #264).
+///
+/// `threshold` must be ≥ 1.  Setting it to 0 is rejected because it would
+/// allow any proposal to execute immediately without any votes.
+pub fn _set_weight_threshold(env: &Env, threshold: u32) {
+    env.storage()
+        .persistent()
+        .set(&crate::types::DataKey::WeightThreshold, &threshold);
+}
+
+/// Get the configured weight threshold, or `None` if not set (issue #264).
+pub fn _get_weight_threshold(env: &Env) -> Option<u32> {
+    env.storage()
+        .persistent()
+        .get(&crate::types::DataKey::WeightThreshold)
 }
 
 // ─────────────────────────────────────────────────────────────────────────────

--- a/contracts/price-oracle/src/lib.rs
+++ b/contracts/price-oracle/src/lib.rs
@@ -209,6 +209,20 @@ pub trait StellarFlowTrait {
     /// Cancel a proposed action.
     fn cancel_proposed_action(env: Env, canceller: Address, action_id: u64) -> Result<(), Error>;
 
+    /// Set the governance weight for a specific admin (issue #264).
+    ///
+    /// Weight must be in the range 1–100. Only an authorized admin may call this.
+    fn set_admin_weight(env: Env, caller: Address, target_admin: Address, weight: u32) -> Result<(), Error>;
+
+    /// Get the governance weight for a specific admin (issue #264).
+    fn get_admin_weight(env: Env, admin: Address) -> u32;
+
+    /// Set the minimum cumulative weight required for a governance proposal to execute (issue #264).
+    fn set_weight_threshold(env: Env, caller: Address, threshold: u32) -> Result<(), Error>;
+
+    /// Get the configured weight threshold, or None if not set (issue #264).
+    fn get_weight_threshold(env: Env) -> Option<u32>;
+
     /// Get the health status of the oracle for the Admin Dashboard.
     ///
     /// Returns aggregated data from multiple storage keys in a single call.
@@ -695,6 +709,15 @@ fn _track_asset(env: &Env, asset: Symbol) {
         env.storage()
             .persistent()
             .set(&DataKey::TrackedAsset(asset), &());
+
+        // Issue #263: keep the isolated HealthTotalAssets slot in sync.
+        let new_count = assets.len();
+        env.storage()
+            .persistent()
+            .set(&DataKey::HealthTotalAssets, &new_count);
+        env.storage()
+            .persistent()
+            .set(&DataKey::HealthLastLedger, &env.ledger().sequence());
     }
 }
 
@@ -1532,6 +1555,15 @@ impl PriceOracle {
         }
         _set_tracked_assets(&env, &updated_assets);
 
+        // Issue #263: keep the isolated HealthTotalAssets slot in sync.
+        let new_count = updated_assets.len();
+        env.storage()
+            .persistent()
+            .set(&DataKey::HealthTotalAssets, &new_count);
+        env.storage()
+            .persistent()
+            .set(&DataKey::HealthLastLedger, &env.ledger().sequence());
+
         Ok(())
     }
 
@@ -1998,6 +2030,11 @@ impl PriceOracle {
         //_log_admin_action(&env, &admin1, AdminAction::TogglePause, Some(format!("New state: {}", new_paused)));
         crate::auth::_set_paused(&env, new_paused);
 
+        // Issue #263: keep the isolated HealthPaused slot in sync.
+        env.storage()
+            .persistent()
+            .set(&DataKey::HealthPaused, &new_paused);
+
         // Emit event
         env.events().publish(
             (Symbol::new(&env, "pause_toggled"),),
@@ -2183,6 +2220,132 @@ impl PriceOracle {
             return 0;
         }
         crate::auth::_get_admin(&env).len()
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // Issue #264: Multi-sig signer threshold weight verification
+    // ─────────────────────────────────────────────────────────────────────────
+
+    /// Set the governance weight for a specific admin (issue #264).
+    ///
+    /// Weight must be in the range 1–100.  A weight of 0 is rejected because a
+    /// zero-weight admin could never contribute to reaching the threshold.
+    /// Only an authorized admin may call this.
+    pub fn set_admin_weight(env: Env, caller: Address, target_admin: Address, weight: u32) -> Result<(), Error> {
+        _require_not_destroyed(&env);
+        _require_initialized(&env);
+        crate::auth::_require_not_frozen(&env);
+        caller.require_auth();
+        crate::auth::_require_authorized(&env, &caller);
+
+        if weight == 0 || weight > 100 {
+            return Err(Error::InvalidWeight);
+        }
+
+        // The target must be a registered admin.
+        if !crate::auth::_is_authorized(&env, &target_admin) {
+            return Err(Error::NotAuthorized);
+        }
+
+        crate::auth::_set_admin_weight(&env, &target_admin, weight);
+
+        env.events().publish(
+            (Symbol::new(&env, "admin_weight_set"),),
+            (caller, target_admin, weight),
+        );
+
+        Ok(())
+    }
+
+    /// Get the governance weight for a specific admin (issue #264).
+    ///
+    /// Returns 1 (the default) when no weight has been explicitly assigned.
+    pub fn get_admin_weight(env: Env, admin: Address) -> u32 {
+        crate::auth::_get_admin_weight(&env, &admin)
+    }
+
+    /// Set the minimum cumulative weight required for a governance proposal to
+    /// execute (issue #264).
+    ///
+    /// `threshold` must be ≥ 1.  Only an authorized admin may call this.
+    /// Once set, `execute_proposed_action` will sum voter weights and compare
+    /// against this value instead of using the simple vote-count threshold.
+    pub fn set_weight_threshold(env: Env, caller: Address, threshold: u32) -> Result<(), Error> {
+        _require_not_destroyed(&env);
+        _require_initialized(&env);
+        crate::auth::_require_not_frozen(&env);
+        caller.require_auth();
+        crate::auth::_require_authorized(&env, &caller);
+
+        if threshold == 0 {
+            return Err(Error::MultiSigValidationFailed);
+        }
+
+        crate::auth::_set_weight_threshold(&env, threshold);
+
+        env.events().publish(
+            (Symbol::new(&env, "weight_threshold_set"),),
+            (caller, threshold),
+        );
+
+        Ok(())
+    }
+
+    /// Get the configured weight threshold (issue #264).
+    ///
+    /// Returns `None` when no threshold has been set (the contract falls back
+    /// to the vote-count threshold from `get_required_threshold`).
+    pub fn get_weight_threshold(env: Env) -> Option<u32> {
+        crate::auth::_get_weight_threshold(&env)
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // Issue #263: Gas-optimized OracleHealth — isolated per-field storage slots
+    // ─────────────────────────────────────────────────────────────────────────
+
+    /// Get the health status of the oracle for the Admin Dashboard (issue #263).
+    ///
+    /// Each field is stored in its own isolated persistent slot so a simple
+    /// dashboard read never deserialises a large monolithic struct.  The
+    /// individual slots are kept in sync by the write paths that mutate each
+    /// field (provider add/remove, pause toggle, asset add/remove).
+    pub fn get_oracle_health(env: Env) -> crate::types::OracleHealth {
+        // ── active_relayers: read the isolated counter slot ──────────────────
+        // Falls back to counting the active-relayers Vec when the isolated slot
+        // has not been written yet (first call after deployment).
+        let active_relayers: u32 = env
+            .storage()
+            .persistent()
+            .get(&DataKey::HealthActiveRelayers)
+            .unwrap_or_else(|| crate::auth::_get_active_relayers(&env).len());
+
+        // ── paused: read the isolated flag slot ──────────────────────────────
+        let paused: bool = env
+            .storage()
+            .persistent()
+            .get(&DataKey::HealthPaused)
+            .unwrap_or_else(|| crate::auth::_is_paused(&env));
+
+        // ── total_assets: read the isolated counter slot ─────────────────────
+        let total_assets: u32 = env
+            .storage()
+            .persistent()
+            .get(&DataKey::HealthTotalAssets)
+            .unwrap_or_else(|| get_tracked_assets(&env).len());
+
+        // ── last_ledger: read the isolated sequence slot ─────────────────────
+        let last_ledger: u32 = env
+            .storage()
+            .persistent()
+            .get(&DataKey::HealthLastLedger)
+            .unwrap_or_else(|| env.ledger().sequence());
+
+        crate::types::OracleHealth {
+            active_relayers,
+            paused,
+            total_assets,
+            last_ledger,
+        }
     }
 
     /// Propose a high-impact action that requires multi-signature approval.
@@ -2444,6 +2607,10 @@ impl PriceOracle {
                 let current_paused = crate::auth::_is_paused(&env);
                 let new_paused = !current_paused;
                 crate::auth::_set_paused(&env, new_paused);
+                // Issue #263: keep the isolated HealthPaused slot in sync.
+                env.storage()
+                    .persistent()
+                    .set(&DataKey::HealthPaused, &new_paused);
                 proposed.executed = true;
                 _log_admin_action(
                     &env,

--- a/contracts/price-oracle/src/types.rs
+++ b/contracts/price-oracle/src/types.rs
@@ -79,6 +79,31 @@ pub enum DataKey {
     SlashToken,
     /// The address of the ecosystem insurance reserve that receives slashed funds.
     InsuranceReserve,
+
+    // ── Issue #264: per-admin signature weight ────────────────────────────────
+    /// Governance weight assigned to a specific admin (u32, 0–100).
+    ///
+    /// Used by the multi-sig weight-accumulation algorithm: before executing a
+    /// proposed action the contract sums the weights of all voters and checks
+    /// the total against `WeightThreshold`. Defaults to 1 when unset so that
+    /// legacy single-weight deployments continue to work without migration.
+    AdminWeight(Address),
+    /// Minimum cumulative weight required for a governance proposal to execute.
+    ///
+    /// When unset the contract falls back to the simple vote-count threshold
+    /// returned by `_get_required_threshold` (expressed as weight units where
+    /// each admin contributes 1 unit).
+    WeightThreshold,
+
+    // ── Issue #263: isolated OracleHealth slots ───────────────────────────────
+    /// Isolated slot: number of active relayers (whitelisted providers).
+    HealthActiveRelayers,
+    /// Isolated slot: whether the contract is currently paused.
+    HealthPaused,
+    /// Isolated slot: total number of tracked assets.
+    HealthTotalAssets,
+    /// Isolated slot: last ledger sequence number at which health was written.
+    HealthLastLedger,
 }
 
 /// Decimal metadata for an asset pair.


### PR DESCRIPTION
Closes #264 - Multi-Sig Signer Threshold Weight Verification:
- Add AdminWeight(Address) and WeightThreshold storage keys in types.rs
- Replace simple vote-count check in _has_reached_threshold with a weight-accumulation algorithm that sums each voter's AdminWeight (defaults to 1 for backward compat) and compares against WeightThreshold
- _get_required_threshold surfaces WeightThreshold when configured
- Add _set_admin_weight, _get_admin_weight, _set_weight_threshold, _get_weight_threshold helpers in auth.rs
- Expose set_admin_weight, get_admin_weight, set_weight_threshold, get_weight_threshold as public contract functions in lib.rs

Closes #263 - Gas-Optimized Instance Data Memory Unpacking:
- Add isolated persistent slots: HealthActiveRelayers, HealthPaused, HealthTotalAssets, HealthLastLedger in types.rs
- _add_provider/_remove_provider sync HealthActiveRelayers on mutation
- _track_asset and remove_asset sync HealthTotalAssets + HealthLastLedger
- toggle_pause and execute_proposed_action TogglePause arm sync HealthPaused
- Implement get_oracle_health reading each field from its own isolated slot with lazy fallback to live computed values (zero-migration)