### PR TITLE
chore: #268 🧬 Replace standard arithmetic with overflow-safe checked …

### DIFF
--- a/contracts/price-oracle/src/lib.rs
+++ b/contracts/price-oracle/src/lib.rs
@@ -507,6 +507,8 @@ pub enum ContractError {
     InvalidMaxDeviation = 45,
     /// Asset price bounds failed validation.
     InvalidPriceBounds = 46,
+    /// Arithmetic operation overflow detected.
+    PriceMathOverflow = 47,
 }
 
 #[contract]
@@ -1031,7 +1033,7 @@ impl PriceOracle {
 
         // Calculate final index price.
         // Because all stored prices are 9-decimal normalized, the division preserves the 9-decimal standard.
-        let index_price = total_weighted_price / (total_weight as i128);
+        let index_price = total_weighted_price.checked_div(total_weight as i128).ok_or(ContractError::PriceMathOverflow)?;
         Ok(index_price)
     }
 
@@ -3317,10 +3319,10 @@ impl PriceOracle {
 
         let mut sum: i128 = 0;
         for (_, price) in twap_buffer.iter() {
-            sum += price;
+            sum = sum.checked_add(price)?;
         }
 
-        Some(sum / (len as i128))
+        sum.checked_div(len as i128)
     }
 
     /// Subscribe a contract to receive price update callbacks.

--- a/contracts/price-oracle/src/median.rs
+++ b/contracts/price-oracle/src/median.rs
@@ -5,6 +5,8 @@ use soroban_sdk::{contracterror, Vec};
 #[repr(u32)]
 pub enum MedianError {
     EmptyInput = 10,
+    /// Arithmetic operation overflow detected.
+    ArithmeticOverflow = 11,
 }
 
 /// Sort a Vec<i128> using insertion sort (no_std compatible).
@@ -45,7 +47,8 @@ pub fn calculate_median(mut prices: Vec<i128>) -> Result<i128, MedianError> {
     } else {
         let lo = prices.get(mid - 1).unwrap();
         let hi = prices.get(mid).unwrap();
-        Ok((lo + hi) / 2)
+        let sum = lo.checked_add(hi).ok_or(MedianError::ArithmeticOverflow)?;
+        Ok(sum.checked_div(2).ok_or(MedianError::ArithmeticOverflow)?)
     }
 }
 


### PR DESCRIPTION
Close #268
…operations

- Add PriceMathOverflow (47) error variant to ContractError enum
- Add ArithmeticOverflow (11) error variant to MedianError enum
- Replace unsafe division in calculate_index_price with checked_div
- Replace unsafe addition/division in get_twap with checked_add/checked_div
- Replace unsafe addition/division in calculate_median with checked_add/checked_div
- Return explicit error on overflow instead of panicking

This ensures 10^7 fixed-point precision conversions and other arithmetic operations prevent core runtime out-of-bounds errors.