### PR TITLE
feat(slashing): add deviation-based tiered penalty calculator

### DIFF
--- a/contracts/price-oracle/src/lib.rs
+++ b/contracts/price-oracle/src/lib.rs
@@ -502,6 +502,8 @@ pub enum ContractError {
     InvalidQueryFee = 50,
     /// The fee vault does not contain enough tokens to satisfy a claim.
     InsufficientVaultBalance = 51,
+    /// Consensus price is zero; deviation cannot be calculated (divide-by-zero guard).
+    DeviationConsensusZero = 52,
     /// A slash amount exceeded the relayer's available stake.
     InsufficientStake = 30,
     /// Missed-block infraction counts must be positive and in range.

--- a/contracts/price-oracle/src/math.rs
+++ b/contracts/price-oracle/src/math.rs
@@ -98,6 +98,43 @@ use crate::Error;
 //     String::from_bytes(env, &out[..pos])
 // }
 
+/// Calculate the absolute deviation between a submitted price and the consensus
+/// median, expressed in basis points (bps).
+///
+/// Formula: `|submitted - consensus| * 10_000 / consensus`
+///
+/// Both values must already be normalized to the same decimal precision before
+/// calling. Use [`normalize_to_nine`] if the inputs have different native precisions.
+///
+/// # Errors
+/// - `Error::DeviationConsensusZero` — when `consensus` is zero (divide-by-zero guard).
+/// - `Error::PriceMathOverflow` — on arithmetic overflow.
+///
+/// # Examples
+/// ```text
+/// calculate_deviation_bps(10_100, 10_000) => Ok(100)   // 1 % = 100 bps
+/// calculate_deviation_bps(10_000, 10_000) => Ok(0)     // identical prices
+/// calculate_deviation_bps(500, 0)         => Err(DeviationConsensusZero)
+/// ```
+pub fn calculate_deviation_bps(submitted: i128, consensus: i128) -> Result<u32, Error> {
+    if consensus == 0 {
+        return Err(Error::DeviationConsensusZero);
+    }
+    let diff = if submitted >= consensus {
+        submitted - consensus
+    } else {
+        consensus - submitted
+    };
+    // diff * 10_000 / consensus — use saturating mul so extreme submissions
+    // (e.g. i128::MAX) don't panic; they saturate to u32::MAX which maps to
+    // the highest DeviationTier (Manipulation).
+    let bps = match diff.checked_mul(10_000) {
+        Some(v) => v.checked_div(consensus).ok_or(Error::PriceMathOverflow)?,
+        None => i128::MAX,
+    };
+    Ok(bps.min(u32::MAX as i128) as u32)
+}
+
 pub fn normalize_to_seven(value: i128, input_decimals: u32) -> Result<i128, Error> {
     if input_decimals < 7 {
         let diff = 7 - input_decimals;
@@ -195,53 +232,88 @@ mod tests {
     use soroban_sdk::Env;
 
     // --- format_price tests ---------------------------------------------------
+    // NOTE: commented out because format_price itself is commented out pending
+    // a decision on whether to re-enable the formatted string output feature.
+
+    // #[test]
+    // fn test_format_price_normal() {
+    //     let env = Env::default();
+    //     // 75050 with 2 decimals → "750.50"
+    //     let s = format_price(&env, 75050, 2);
+    //     assert_eq!(s.to_string(), "750.50");
+    // }
+
+    // #[test]
+    // fn test_format_price_small_value() {
+    //     let env = Env::default();
+    //     // 50 with 3 decimals → "0.050"
+    //     let s = format_price(&env, 50, 3);
+    //     assert_eq!(s.to_string(), "0.050");
+    // }
+
+    // #[test]
+    // fn test_format_price_no_decimals() {
+    //     let env = Env::default();
+    //     // 12345 with 0 decimals → "12345"
+    //     let s = format_price(&env, 12345, 0);
+    //     assert_eq!(s.to_string(), "12345");
+    // }
+
+    // #[test]
+    // fn test_format_price_zero() {
+    //     let env = Env::default();
+    //     // 0 with 2 decimals → "0.00"
+    //     let s = format_price(&env, 0, 2);
+    //     assert_eq!(s.to_string(), "0.00");
+    // }
+
+    // #[test]
+    // fn test_format_price_exact_decimal_boundary() {
+    //     let env = Env::default();
+    //     // 1 with 1 decimal → "0.1"
+    //     let s = format_price(&env, 1, 1);
+    //     assert_eq!(s.to_string(), "0.1");
+    // }
+
+    // #[test]
+    // fn test_format_price_negative() {
+    //     let env = Env::default();
+    //     // -75050 with 2 decimals → "-750.50"
+    //     let s = format_price(&env, -75050, 2);
+    //     assert_eq!(s.to_string(), "-750.50");
+    // }
+
+    // --- calculate_deviation_bps tests ----------------------------------------
 
     #[test]
-    fn test_format_price_normal() {
-        let env = Env::default();
-        // 75050 with 2 decimals → "750.50"
-        let s = format_price(&env, 75050, 2);
-        assert_eq!(s.to_string(), "750.50");
+    fn test_deviation_bps_identical() {
+        assert_eq!(calculate_deviation_bps(10_000, 10_000), Ok(0));
     }
 
     #[test]
-    fn test_format_price_small_value() {
-        let env = Env::default();
-        // 50 with 3 decimals → "0.050"
-        let s = format_price(&env, 50, 3);
-        assert_eq!(s.to_string(), "0.050");
+    fn test_deviation_bps_above_consensus() {
+        // 10_100 vs 10_000 → 100 bps (1 %)
+        assert_eq!(calculate_deviation_bps(10_100, 10_000), Ok(100));
     }
 
     #[test]
-    fn test_format_price_no_decimals() {
-        let env = Env::default();
-        // 12345 with 0 decimals → "12345"
-        let s = format_price(&env, 12345, 0);
-        assert_eq!(s.to_string(), "12345");
+    fn test_deviation_bps_below_consensus() {
+        // 9_800 vs 10_000 → 200 bps (2 %)
+        assert_eq!(calculate_deviation_bps(9_800, 10_000), Ok(200));
     }
 
     #[test]
-    fn test_format_price_zero() {
-        let env = Env::default();
-        // 0 with 2 decimals → "0.00"
-        let s = format_price(&env, 0, 2);
-        assert_eq!(s.to_string(), "0.00");
+    fn test_deviation_bps_zero_consensus() {
+        assert_eq!(
+            calculate_deviation_bps(500, 0),
+            Err(Error::DeviationConsensusZero)
+        );
     }
 
     #[test]
-    fn test_format_price_exact_decimal_boundary() {
-        let env = Env::default();
-        // 1 with 1 decimal → "0.1"
-        let s = format_price(&env, 1, 1);
-        assert_eq!(s.to_string(), "0.1");
-    }
-
-    #[test]
-    fn test_format_price_negative() {
-        let env = Env::default();
-        // -75050 with 2 decimals → "-750.50"
-        let s = format_price(&env, -75050, 2);
-        assert_eq!(s.to_string(), "-750.50");
+    fn test_deviation_bps_extreme_saturates_to_u32_max() {
+        let result = calculate_deviation_bps(i128::MAX, 1);
+        assert_eq!(result, Ok(u32::MAX));
     }
 
     // --- normalize_to_seven tests ---------------------------------------------

--- a/contracts/price-oracle/src/slashing.rs
+++ b/contracts/price-oracle/src/slashing.rs
@@ -312,6 +312,135 @@ pub fn execute_slash_internal(
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
+// Deviation-based tiered slashing
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Classification of a price submission's deviation from the consensus median.
+///
+/// Tiers are expressed in basis points (bps), where 100 bps = 1 %.
+/// The `Noise` tier (< 50 bps) represents normal network variance and carries
+/// no penalty.  Higher tiers indicate increasingly intentional manipulation and
+/// attract proportionally larger slash multipliers.
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+pub enum DeviationTier {
+    /// < 50 bps — network noise or minor communication delay.  No penalty.
+    Noise,
+    /// 50 – 199 bps — minor deviation.  1× base multiplier.
+    Minor,
+    /// 200 – 499 bps — moderate deviation.  3× base multiplier.
+    Moderate,
+    /// 500 – 999 bps — significant deviation.  7× base multiplier.
+    Significant,
+    /// ≥ 1 000 bps — extreme deviation consistent with price manipulation.  15× base multiplier.
+    Manipulation,
+}
+
+/// Map a raw deviation in basis points to the corresponding [`DeviationTier`].
+pub fn classify_deviation(deviation_bps: u32) -> DeviationTier {
+    if deviation_bps < 50 {
+        DeviationTier::Noise
+    } else if deviation_bps < 200 {
+        DeviationTier::Minor
+    } else if deviation_bps < 500 {
+        DeviationTier::Moderate
+    } else if deviation_bps < 1_000 {
+        DeviationTier::Significant
+    } else {
+        DeviationTier::Manipulation
+    }
+}
+
+/// Return the slash multiplier associated with a [`DeviationTier`].
+///
+/// A multiplier of `0` means no slash is applied (Noise tier).
+/// The multiplier is applied on top of the relayer's existing missed-block
+/// multiplier inside [`report_price_deviation`], so the total penalty grows
+/// proportionally with *both* the severity of the deviation *and* the
+/// relayer's prior infraction history.
+pub fn deviation_multiplier(tier: DeviationTier) -> i128 {
+    match tier {
+        DeviationTier::Noise => 0,
+        DeviationTier::Minor => 1,
+        DeviationTier::Moderate => 3,
+        DeviationTier::Significant => 7,
+        DeviationTier::Manipulation => 15,
+    }
+}
+
+/// Evaluate a relayer's price submission against the finalized consensus median
+/// and apply a proportional slash when the deviation crosses a meaningful threshold.
+///
+/// This function distinguishes accidental network hiccups (< 50 bps) from
+/// deliberate price manipulation (≥ 1 000 bps), applying a larger penalty the
+/// further the submitted price strays from the consensus.
+///
+/// # Penalty model
+/// ```text
+/// final_penalty = base_slash_amount × tier_multiplier × missed_blocks_multiplier
+/// ```
+/// where `tier_multiplier` comes from [`deviation_multiplier`] and
+/// `missed_blocks_multiplier` is the exponential penalty already accumulated
+/// from the relayer's downtime history (see [`execute_slash_internal`]).
+///
+/// # Parameters
+/// - `executor`: the admin address triggering this evaluation.
+/// - `relayer`: the provider whose submission is under review.
+/// - `submitted_price`: price the relayer submitted, normalized to 9 decimals.
+/// - `consensus_price`: finalized median price at the same precision.
+/// - `base_slash_amount`: base token amount to slash before tier scaling.
+///
+/// # Returns
+/// The tier-scaled amount passed to the slash engine (`0` for the Noise tier),
+/// or an error.  The actual token deducted from the relayer's stake is
+/// `base_slash_amount × tier_multiplier × missed_blocks_multiplier`.
+pub fn report_price_deviation(
+    env: &Env,
+    executor: &Address,
+    relayer: &Address,
+    submitted_price: i128,
+    consensus_price: i128,
+    base_slash_amount: i128,
+) -> Result<i128, Error> {
+    let deviation_bps =
+        crate::math::calculate_deviation_bps(submitted_price, consensus_price)?;
+    let tier = classify_deviation(deviation_bps);
+    let tier_mult = deviation_multiplier(tier);
+
+    // Persist for audit and off-chain indexing regardless of tier.
+    env.storage()
+        .persistent()
+        .set(&DataKey::ProviderLastDeviationBps(relayer.clone()), &deviation_bps);
+
+    // Noise tier — record only, no slash.
+    if tier_mult == 0 {
+        return Ok(0);
+    }
+
+    // Scale the base amount by the tier multiplier.
+    // execute_slash_internal will then further multiply by the missed-blocks
+    // multiplier, yielding: final = base × tier_mult × missed_blocks_mult.
+    let tier_scaled = base_slash_amount
+        .checked_mul(tier_mult)
+        .ok_or(Error::InvalidSlashAmount)?;
+
+    execute_slash_internal(env, executor, relayer, tier_scaled)?;
+
+    env.events().publish(
+        (Symbol::new(env, "deviation_slash"),),
+        (
+            relayer.clone(),
+            submitted_price,
+            consensus_price,
+            deviation_bps,
+            tier_mult,
+            tier_scaled,
+        ),
+    );
+
+    Ok(tier_scaled)
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
 // Tests
 // ─────────────────────────────────────────────────────────────────────────────
 
@@ -417,5 +546,86 @@ mod slashing_tests {
         assert_eq!(get_consecutive_missed_blocks(&env, &relayer), 0);
         assert_eq!(get_uptime_streak_start(&env, &relayer), None);
         assert_eq!(get_slash_multiplier(&env, &relayer).unwrap(), 1);
+    }
+
+    // ── classify_deviation ────────────────────────────────────────────────────
+
+    #[test]
+    fn test_classify_deviation_noise() {
+        assert_eq!(classify_deviation(0), DeviationTier::Noise);
+        assert_eq!(classify_deviation(49), DeviationTier::Noise);
+    }
+
+    #[test]
+    fn test_classify_deviation_minor() {
+        assert_eq!(classify_deviation(50), DeviationTier::Minor);
+        assert_eq!(classify_deviation(199), DeviationTier::Minor);
+    }
+
+    #[test]
+    fn test_classify_deviation_moderate() {
+        assert_eq!(classify_deviation(200), DeviationTier::Moderate);
+        assert_eq!(classify_deviation(499), DeviationTier::Moderate);
+    }
+
+    #[test]
+    fn test_classify_deviation_significant() {
+        assert_eq!(classify_deviation(500), DeviationTier::Significant);
+        assert_eq!(classify_deviation(999), DeviationTier::Significant);
+    }
+
+    #[test]
+    fn test_classify_deviation_manipulation() {
+        assert_eq!(classify_deviation(1_000), DeviationTier::Manipulation);
+        assert_eq!(classify_deviation(u32::MAX), DeviationTier::Manipulation);
+    }
+
+    // ── deviation_multiplier ──────────────────────────────────────────────────
+
+    #[test]
+    fn test_deviation_multiplier_noise_is_zero() {
+        assert_eq!(deviation_multiplier(DeviationTier::Noise), 0);
+    }
+
+    #[test]
+    fn test_deviation_multiplier_tiers() {
+        assert_eq!(deviation_multiplier(DeviationTier::Minor), 1);
+        assert_eq!(deviation_multiplier(DeviationTier::Moderate), 3);
+        assert_eq!(deviation_multiplier(DeviationTier::Significant), 7);
+        assert_eq!(deviation_multiplier(DeviationTier::Manipulation), 15);
+    }
+
+    // ── calculate_deviation_bps (via math module) ─────────────────────────────
+
+    #[test]
+    fn test_deviation_bps_identical_prices() {
+        assert_eq!(crate::math::calculate_deviation_bps(10_000, 10_000), Ok(0));
+    }
+
+    #[test]
+    fn test_deviation_bps_one_percent() {
+        // submitted is 1 % above consensus → 100 bps
+        assert_eq!(crate::math::calculate_deviation_bps(10_100, 10_000), Ok(100));
+    }
+
+    #[test]
+    fn test_deviation_bps_below_consensus() {
+        // submitted is 2 % below consensus → 200 bps
+        assert_eq!(crate::math::calculate_deviation_bps(9_800, 10_000), Ok(200));
+    }
+
+    #[test]
+    fn test_deviation_bps_zero_consensus_returns_error() {
+        assert_eq!(
+            crate::math::calculate_deviation_bps(500, 0),
+            Err(crate::Error::DeviationConsensusZero)
+        );
+    }
+
+    #[test]
+    fn test_deviation_bps_extreme_submitted_saturates() {
+        // i128::MAX submitted vs consensus 1 — overflows internally, saturates to u32::MAX
+        let result = crate::math::calculate_deviation_bps(i128::MAX, 1);
+        assert_eq!(result, Ok(u32::MAX));
     }
 }

--- a/contracts/price-oracle/src/types.rs
+++ b/contracts/price-oracle/src/types.rs
@@ -120,6 +120,10 @@ pub enum DataKey {
     /// The ledger sequence number when the oracle last resumed from a halt.
     /// Used to ignore tracking metrics (TWAP, RecentEvents) from before the recovery.
     BaselineLedger,
+    /// Last recorded deviation (in basis points) between a provider's submitted
+    /// price and the consensus median.  Written on every `report_price_deviation`
+    /// call for audit and off-chain indexing purposes.
+    ProviderLastDeviationBps(Address),
 }
 
 /// Decimal metadata for an asset pair.


### PR DESCRIPTION
 Closes #367 

  Implements deviation-based tiered slashing to distinguish network noise
  from deliberate price manipulation, addressing the flat-penalty weakness
  in the economic safety model.

  Changes:
  - calculate_deviation_bps: computes |submitted - consensus| * 10_000 / consensus
    with overflow saturation and divide-by-zero guard (DeviationConsensusZero = 52)
  - DeviationTier enum: Noise / Minor / Moderate / Significant / Manipulation
  - classify_deviation: maps raw bps to tier (thresholds: 50 / 200 / 500 / 1000)
  - deviation_multiplier: returns 0 / 1 / 3 / 7 / 15 per tier
  - report_price_deviation: orchestrates full flow — records deviation bps on-chain,
    skips slash for Noise tier, applies base × tier_mult to execute_slash_internal
    (which further applies missed_blocks_mult), emits deviation_slash event
  - DataKey::ProviderLastDeviationBps(Address): persistent audit trail per relayer
  - Commented out unreachable format_price tests (function was already commented out)

  Penalty model:
    final_penalty = base_slash_amount × tier_multiplier × missed_blocks_multiplier

  Test coverage: 15 new unit tests across math.rs and slashing.rs covering
  tier boundaries, bps calculation, overflow saturation, and zero-consensus guard.