### PR TITLE
fix(price-oracle): auto-extend relayer TTL in get_price path (#364)

### DIFF
--- a/contracts/price-oracle/src/lib.rs
+++ b/contracts/price-oracle/src/lib.rs
@@ -431,6 +431,15 @@ const VOLATILITY_THRESHOLD_BPS: i128 = 500;
 /// Absolute floor for governance quorum configuration.
 const MIN_SAFE_QUORUM_THRESHOLD: u32 = 2;
 
+/// Minimum remaining TTL (in ledgers) for a relayer node profile before an
+/// automatic extension is triggered during `get_price` queries.
+const PROVIDER_TTL_EXTENSION_THRESHOLD: u32 = 5_000;
+
+/// Target TTL (in ledgers from current ledger) to extend a relayer profile to
+/// when its remaining TTL drops below `PROVIDER_TTL_EXTENSION_THRESHOLD`.
+/// ~30 days at ~5 s/ledger ≈ 518_400 ledgers; using a conservative 100_000.
+const PROVIDER_TTL_EXTENSION_TARGET: u32 = 100_000;
+
 /// ContractError types for the price oracle contract
 #[contracterror]
 #[derive(Copy, Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
@@ -948,6 +957,23 @@ fn read_price_floor(env: &Env, asset: &Symbol) -> Option<i128> {
         .get(&DataKey::PriceFloorEntry(asset.clone()))
 }
 
+/// Extend the persistent storage TTL of a relayer node's profile entries if
+/// the remaining TTL has fallen below [`PROVIDER_TTL_EXTENSION_THRESHOLD`].
+///
+/// Called automatically from the `get_price` query path so that active
+/// relayers never lose their on-chain state due to rent-based eviction.
+fn _extend_provider_ttl_if_needed(env: &Env, provider: &Address) {
+    let storage = env.storage().persistent();
+    let stake_key = DataKey::ProviderStake(provider.clone());
+    let last_seen_key = DataKey::ProviderLastSeenLedger(provider.clone());
+    if storage.has(&stake_key) {
+        storage.extend_ttl(&stake_key, PROVIDER_TTL_EXTENSION_THRESHOLD, PROVIDER_TTL_EXTENSION_TARGET);
+    }
+    if storage.has(&last_seen_key) {
+        storage.extend_ttl(&last_seen_key, PROVIDER_TTL_EXTENSION_THRESHOLD, PROVIDER_TTL_EXTENSION_TARGET);
+    }
+}
+
 fn enforce_price_floor(env: &Env, asset: &Symbol, price: i128) -> Result<(), ContractError> {
     if let Some(price_floor) = read_price_floor(env, asset) {
         if price < price_floor {
@@ -1434,6 +1460,8 @@ impl PriceOracle {
                     return Err(ContractError::AssetNotFound);
                 }
                 Self::process_query_fee(&env, &price_data.provider)?;
+                // Issue #364: auto-extend relayer node profile TTL when below threshold.
+                _extend_provider_ttl_if_needed(&env, &price_data.provider);
                 Ok(price_data)
             }
             None => Err(ContractError::AssetNotFound),


### PR DESCRIPTION
## Summary

Fixes #364

Inactive relayer node profiles risk rent-based data eviction if their persistent storage TTL drops too low. This PR automatically extends the TTL of a relayer's `ProviderStake` and `ProviderLastSeenLedger` storage entries inside the `get_price` query path whenever the remaining TTL falls below the 5,000-ledger boundary.

## Changes

- **`contracts/price-oracle/src/lib.rs`**
  - Added `PROVIDER_TTL_EXTENSION_THRESHOLD = 5_000` — triggers extension when TTL is below this many ledgers
  - Added `PROVIDER_TTL_EXTENSION_TARGET = 100_000` — extends to this many ledgers from current ledger
  - Added `_extend_provider_ttl_if_needed(env, provider)` — private helper that conditionally calls `env.storage().persistent().extend_ttl()` on both `ProviderStake` and `ProviderLastSeenLedger` keys
  - Hooked helper into `get_price` after a successful price retrieval and fee processing

## How it works

`extend_ttl(threshold, extend_to)` is a no-op when the current TTL is already ≥ `threshold`, so the operation is cheap and safe to call on every successful query. The `.has()` guard ensures we don't attempt to extend TTL on entries that don't yet exist (unregistered relayers).

## Testing

Zero new compile errors introduced. Pre-existing 34 errors in the codebase are unrelated to this change (confirmed by diffing error output before/after).