### PR TITLE
feat: #363 compact identical price rows before median sort

### DIFF
--- a/contracts/price-oracle/src/lib.rs
+++ b/contracts/price-oracle/src/lib.rs
@@ -865,19 +865,39 @@ fn truncate_buffer_by_weight(env: &Env, buffer: &mut PriceBuffer) {
 
 /// Calculate the median price from the buffer entries.
 /// Returns None if the buffer is empty.
+///
+/// Issue #363: instead of copying every row into a flat vector and sorting all
+/// of them, we compact identical prices into `(price, count)` buckets in one
+/// linear pass ("vector compacting"), so the sort inside the median runs only
+/// over DISTINCT price values. Providers are already deduplicated per ledger
+/// (see `has_provider_submitted`), so identical prices here are independent
+/// votes — `count` preserves their multiplicity and the median is unchanged.
 fn calculate_median_from_buffer(env: &Env, buffer: &PriceBuffer) -> Option<i128> {
     if buffer.entries.len() == 0 {
         return None;
     }
 
-    // Extract prices into a Vec for sorting
-    let mut prices = soroban_sdk::Vec::new(env);
+    // Linear compaction pass: fold identical prices into (price, count) buckets.
+    let mut compacted: soroban_sdk::Vec<(i128, u32)> = soroban_sdk::Vec::new(env);
     for entry in buffer.entries.iter() {
-        prices.push_back(entry.price);
+        let price = entry.price;
+        let len = compacted.len();
+        let mut found = false;
+        for i in 0..len {
+            let (value, count) = compacted.get(i).unwrap();
+            if value == price {
+                compacted.set(i, (value, count + 1));
+                found = true;
+                break;
+            }
+        }
+        if !found {
+            compacted.push_back((price, 1));
+        }
     }
 
-    // Use the existing median calculation
-    crate::median::calculate_median(prices).ok()
+    // Sort distinct values + median via cumulative counts (result-preserving).
+    crate::median::calculate_median_compacted(compacted).ok()
 }
 
 /// Adds an asset to the list of tracked assets if it's not already present.

--- a/contracts/price-oracle/src/median.rs
+++ b/contracts/price-oracle/src/median.rs
@@ -52,6 +52,77 @@ pub fn calculate_median(mut prices: Vec<i128>) -> Result<i128, MedianError> {
     }
 }
 
+/// Value at multiset index `target` (0-based) in an ascending `(value, count)`
+/// vector, located via cumulative counts.
+fn value_at(pairs: &Vec<(i128, u32)>, target: u64) -> i128 {
+    let len = pairs.len();
+    let mut cum: u64 = 0;
+    let mut last: i128 = 0;
+    for i in 0..len {
+        let (v, c) = pairs.get(i).unwrap();
+        last = v;
+        cum += c as u64;
+        if target < cum {
+            return v;
+        }
+    }
+    // `target` is always < total by construction; fall back to the largest value.
+    last
+}
+
+/// Median of a multiset represented as compacted `(value, count)` pairs.
+///
+/// The insertion sort below runs only over the DISTINCT values, while `count`
+/// preserves each value's true multiplicity. The result is therefore identical
+/// to sorting the full expanded multiset — this is the gas saving from
+/// "vector compacting" without altering the consensus median.
+#[allow(dead_code)]
+pub fn calculate_median_compacted(mut pairs: Vec<(i128, u32)>) -> Result<i128, MedianError> {
+    let len = pairs.len();
+    if len == 0 {
+        return Err(MedianError::EmptyInput);
+    }
+
+    // Total number of original rows across all buckets.
+    let mut total: u64 = 0;
+    for i in 0..len {
+        let (_, c) = pairs.get(i).unwrap();
+        total = total
+            .checked_add(c as u64)
+            .ok_or(MedianError::ArithmeticOverflow)?;
+    }
+    if total == 0 {
+        return Err(MedianError::EmptyInput);
+    }
+
+    // Insertion sort over DISTINCT values only (ascending by value).
+    for i in 1..len {
+        let mut j = i;
+        while j > 0 {
+            let (va, _) = pairs.get(j - 1).unwrap();
+            let (vb, _) = pairs.get(j).unwrap();
+            if va > vb {
+                let a = pairs.get(j - 1).unwrap();
+                let b = pairs.get(j).unwrap();
+                pairs.set(j - 1, b);
+                pairs.set(j, a);
+                j -= 1;
+            } else {
+                break;
+            }
+        }
+    }
+
+    if total % 2 == 1 {
+        Ok(value_at(&pairs, total / 2))
+    } else {
+        let lo = value_at(&pairs, total / 2 - 1);
+        let hi = value_at(&pairs, total / 2);
+        let sum = lo.checked_add(hi).ok_or(MedianError::ArithmeticOverflow)?;
+        Ok(sum.checked_div(2).ok_or(MedianError::ArithmeticOverflow)?)
+    }
+}
+
 #[cfg(test)]
 mod median_tests {
     use crate::median::{calculate_median, MedianError};
@@ -83,5 +154,47 @@ mod median_tests {
         let env = Env::default();
         let prices = soroban_sdk::Vec::<i128>::new(&env);
         assert_eq!(calculate_median(prices), Err(MedianError::EmptyInput));
+    }
+
+    #[test]
+    fn test_compacted_matches_expanded_with_duplicates() {
+        // Five votes of 750 and one of 900: true median is 750.
+        // Naive dedup would give median(750, 900) = 825 — the bug we avoid.
+        let env = Env::default();
+        let pairs = vec![&env, (750_i128, 5_u32), (900_i128, 1_u32)];
+        assert_eq!(crate::median::calculate_median_compacted(pairs), Ok(750));
+    }
+
+    #[test]
+    fn test_compacted_even_total() {
+        // Expanded multiset: [740,740,760,770] → median = (740+760)/2 = 750.
+        let env = Env::default();
+        let pairs = vec![&env, (740_i128, 2_u32), (760_i128, 1_u32), (770_i128, 1_u32)];
+        assert_eq!(crate::median::calculate_median_compacted(pairs), Ok(750));
+    }
+
+    #[test]
+    fn test_compacted_unsorted_input() {
+        // [800,800,750,900,900,900] sorted → median = (800+900)/2 = 850.
+        let env = Env::default();
+        let pairs = vec![&env, (800_i128, 2_u32), (750_i128, 1_u32), (900_i128, 3_u32)];
+        assert_eq!(crate::median::calculate_median_compacted(pairs), Ok(850));
+    }
+
+    #[test]
+    fn test_compacted_single_bucket() {
+        let env = Env::default();
+        let pairs = vec![&env, (999_i128, 4_u32)];
+        assert_eq!(crate::median::calculate_median_compacted(pairs), Ok(999));
+    }
+
+    #[test]
+    fn test_compacted_empty_returns_error() {
+        let env = Env::default();
+        let pairs = soroban_sdk::Vec::<(i128, u32)>::new(&env);
+        assert_eq!(
+            crate::median::calculate_median_compacted(pairs),
+            Err(MedianError::EmptyInput)
+        );
     }
 }


### PR DESCRIPTION
# feat: #363 compact identical price rows before median sort
 
## Summary
 
Refactors the validator payload iterator (`calculate_median_from_buffer`) to compact identical price values into `(price, count)` buckets in a single linear pass before sorting, so the median sort runs only over distinct values rather than every row.
 
## Motivation
 
Closes #363. During high-volatility telemetry sweeps, many nodes report identical price rows. The previous path copied every entry into a flat vector and sorted all of them. Compacting first means the sort operates on the distinct set, trimming work in the common case where duplicates are dense.
 
## Approach (note on correctness)
 
The issue describes pruning duplicate rows. Dropping identical prices outright would corrupt the median — providers are already deduplicated per ledger (`has_provider_submitted`), so identical prices are independent votes, and a median must count each one. Instead, this preserves each value's multiplicity via `count` and computes the median using cumulative counts, so the result is identical to sorting the full expanded multiset. This is the "vector compacting" framing from the issue title, done without altering the consensus price.
 
## Changes
 
- `median.rs`: added `calculate_median_compacted((price, count))`, which insertion-sorts only distinct values and locates the median via cumulative counts; plus a `value_at` helper.
- `lib.rs`: `calculate_median_from_buffer` now folds identical prices into `(price, count)` buckets in one linear pass before calling the new function.
## Testing
 
The median compaction logic is covered by 9 unit tests (5 new for the compacted path, 4 existing), all passing on soroban-sdk 20.5.0. Verified in isolation because the crate's full test suite does not currently compile against the pinned `soroban-sdk = "20.0.0"` — the committed tests in `test.rs`/`delegate_tests.rs` use the 21+ API (`env.register`, `set_timestamp`, `set_sequence_number`). The added logic is self-contained arithmetic and does not touch those files.

closes #363.
