### PR TITLE
fix(price-oracle): borrow batch vectors in validation path

### DIFF
--- a/contracts/price-oracle/src/lib.rs
+++ b/contracts/price-oracle/src/lib.rs
@@ -1125,58 +1125,7 @@ impl PriceOracle {
         if crate::auth::_is_halted(&env) {
             panic_with_error!(&env, ContractError::EmergencyHalted);
         }
-        if components.is_empty() {
-            return Err(ContractError::AssetNotFound);
-        }
-
-        let mut total_weighted_price: i128 = 0;
-        let mut total_weight: u32 = 0;
-
-        for component in components.iter() {
-            // Boundary check (issue #278): reject uninitialized asset pairs before
-            // entering the calculation loop to prevent runtime errors on stale slots.
-            if !env
-                .storage()
-                .persistent()
-                .has(&DataKey::TrackedAsset(component.asset.clone()))
-            {
-                return Err(ContractError::AssetNotFound);
-            }
-
-            // Reject zero-weight components to avoid silently skewing the index.
-            if component.weight == 0 {
-                return Err(ContractError::InvalidWeight);
-            }
-
-            // Fetch the verified price.
-            // If any asset is missing or stale, this cleanly propagates ContractError::AssetNotFound.
-            let price_data = Self::get_price(env.clone(), component.asset.clone(), true)?;
-
-            let weight_i128: i128 = component.weight.into();
-
-            // Safe math to prevent overflow panics
-            let weighted_val = price_data
-                .price
-                .checked_mul(weight_i128)
-                .ok_or(ContractError::InvalidPrice)?;
-
-            total_weighted_price = total_weighted_price
-                .checked_add(weighted_val)
-                .ok_or(ContractError::InvalidPrice)?;
-
-            total_weight = total_weight
-                .checked_add(component.weight)
-                .unwrap_or(total_weight);
-        }
-
-        if total_weight == 0 {
-            return Err(ContractError::InvalidWeight);
-        }
-
-        // Calculate final index price.
-        // Because all stored prices are 9-decimal normalized, the division preserves the 9-decimal standard.
-        let index_price = total_weighted_price.checked_div(total_weight as i128).ok_or(ContractError::PriceMathOverflow)?;
-        Ok(index_price)
+        validation::calculate_index_price(&env, &components)
     }
 
     pub fn init_admin(env: Env, admin: Address) {
@@ -1327,27 +1276,7 @@ impl PriceOracle {
         admin.require_auth();
         crate::auth::_require_authorized(&env, &admin);
 
-        if configs.len() == 0 {
-            return Err(ContractError::InvalidAssetConfig);
-        }
-
-        if max_deviation_bps <= 0 || max_deviation_bps > 10_000 {
-            return Err(ContractError::InvalidMaxDeviation);
-        }
-
-        for config in configs.iter() {
-            if config.min_price <= 0
-                || config.max_price <= 0
-                || config.min_price > config.max_price
-            {
-                return Err(ContractError::InvalidPriceBounds);
-            }
-            if let Some(price_floor) = config.price_floor {
-                if price_floor <= 0 || price_floor > config.max_price {
-                    return Err(ContractError::InvalidPriceBounds);
-                }
-            }
-        }
+        validation::validate_asset_registration_configs(&configs, max_deviation_bps)?;
 
         if let Some(existing) = env
             .storage()
@@ -2156,16 +2085,7 @@ impl PriceOracle {
     /// by snapshot tests and migration tooling. It does **not** touch
     /// `VerifiedPrice` or `CommunityPrice` buckets; use `remove_asset` for that.
     pub fn clear_assets(env: Env, assets: soroban_sdk::Vec<Symbol>) -> Result<(), ContractError> {
-        if assets.len() > MAX_CLEAR_ASSETS {
-            return Err(ContractError::TooManyAssets);
-        }
-
-        let storage = env.storage().persistent();
-        for asset in assets.iter() {
-            storage.remove(&DataKey::Price(asset));
-        }
-
-        Ok(())
+        validation::clear_assets(&env, &assets)
     }
 
     /// Update the price for a specific asset (authorized backend relayer function).
@@ -2992,16 +2912,17 @@ impl PriceOracle {
     ///
     /// # Returns
     /// The action ID that can be used to vote on this proposal
-    /// Set the minimum number of votes required for a governance proposal to reach quorum (issue #292).
-    /// Admin-only. Default is 1 (no floor) when unset.
+    /// Set the minimum number of votes required for a governance proposal to
+    /// reach quorum (issue #292).
+    ///
+    /// Admin-only. Default is 1 (no floor) when unset. Values below the hard
+    /// floor are rejected, and the getter clamps legacy low storage to the
+    /// same minimum.
     pub fn set_min_quorum_threshold(
         env: Env,
         admin: Address,
         threshold: u32,
     ) -> Result<(), ContractError> {
-    /// Admin-only. Values below the hard floor are rejected, and the getter
-    /// clamps legacy low storage to the same minimum.
-    pub fn set_min_quorum_threshold(env: Env, admin: Address, threshold: u32) -> Result<(), ContractError> {
         _require_not_destroyed(&env);
         _require_initialized(&env);
         crate::auth::_require_not_frozen(&env);
@@ -4120,3 +4041,4 @@ mod role_registry;
 mod slashing;
 mod test;
 mod types;
+mod validation;

--- a/contracts/price-oracle/src/math.rs
+++ b/contracts/price-oracle/src/math.rs
@@ -167,44 +167,21 @@ pub fn normalize_to_seven(value: i128, input_decimals: u32) -> Result<i128, Erro
 /// normalize_to_nine(1_000_000_000_00, 11) => 1_000_000_000 (scale down)
 /// ```
 pub fn normalize_to_nine(value: i128, native_decimals: u32) -> Result<i128, Error> {
-    // This normalization is a critical fixed-point boundary.
-    // To reduce rounding/truncation drift when this function is used
-    // inside multi-step rate translations, we do the multiply/divide
-    // sequence in a temporarily up-scaled space.
-
     const TARGET: u32 = 9;
-    const INTERIOR_SCALE: i128 = 1_000_000_000_000_000; // 10^15
 
-    // NOTE: INTERIOR_SCALE is chosen so that the final result remains within
-    // the project's 9-decimal fixed-point footprint by dividing back down
-    // after the translation.
-
-    let scaled = value
-        .checked_mul(INTERIOR_SCALE)
-        .ok_or(Error::PriceMathOverflow)?;
-
-    let normalized_in_interior_space = if native_decimals < TARGET {
+    if native_decimals < TARGET {
         let diff = TARGET - native_decimals;
         let multiplier = 10_i128.checked_pow(diff).ok_or(Error::PriceMathOverflow)?;
         value
-            .checked_mul(multiplier)
-            .ok_or(Error::PriceMathOverflow)
-        scaled
             .checked_mul(multiplier)
             .ok_or(Error::PriceMathOverflow)?
     } else if native_decimals > TARGET {
         let diff = native_decimals - TARGET;
         let divisor = 10_i128.checked_pow(diff).ok_or(Error::PriceMathOverflow)?;
-        scaled
-            .checked_div(divisor)
-            .ok_or(Error::PriceMathOverflow)?
+        value.checked_div(divisor).ok_or(Error::PriceMathOverflow)
     } else {
-        scaled
-    };
-
-    normalized_in_interior_space
-        .checked_div(INTERIOR_SCALE)
-        .ok_or(Error::PriceMathOverflow)
+        Ok(value)
+    }
 }
 
 /// Calculate the inverse of a price (e.g., NGN/XLM → XLM/NGN).

--- a/contracts/price-oracle/src/validation.rs
+++ b/contracts/price-oracle/src/validation.rs
@@ -1,0 +1,105 @@
+//! Shared ref-based helpers for vector-heavy public methods.
+//!
+//! These helpers borrow Soroban `Vec` inputs so large payloads stay behind a
+//! shared immutable reference while the contract performs validation and batch
+//! processing.
+
+use soroban_sdk::{Env, Symbol, Vec};
+
+use crate::{
+    types::{AssetRegistrationConfig, AssetWeight, DataKey},
+    ContractError, MAX_CLEAR_ASSETS,
+};
+
+/// Validate a batch of asset registration configs without taking ownership of
+/// the vector payload.
+pub fn validate_asset_registration_configs(
+    configs: &Vec<AssetRegistrationConfig>,
+    max_deviation_bps: i128,
+) -> Result<(), ContractError> {
+    if configs.len() == 0 {
+        return Err(ContractError::InvalidAssetConfig);
+    }
+
+    if max_deviation_bps <= 0 || max_deviation_bps > 10_000 {
+        return Err(ContractError::InvalidMaxDeviation);
+    }
+
+    for config in configs.iter() {
+        if config.min_price <= 0 || config.max_price <= 0 || config.min_price > config.max_price {
+            return Err(ContractError::InvalidPriceBounds);
+        }
+
+        if let Some(price_floor) = config.price_floor {
+            if price_floor <= 0 || price_floor > config.max_price {
+                return Err(ContractError::InvalidPriceBounds);
+            }
+        }
+    }
+
+    Ok(())
+}
+
+/// Compute the weighted index price from a borrowed basket of assets.
+pub fn calculate_index_price(
+    env: &Env,
+    components: &Vec<AssetWeight>,
+) -> Result<i128, ContractError> {
+    if components.is_empty() {
+        return Err(ContractError::AssetNotFound);
+    }
+
+    let mut total_weighted_price: i128 = 0;
+    let mut total_weight: u32 = 0;
+
+    for component in components.iter() {
+        if !env
+            .storage()
+            .persistent()
+            .has(&DataKey::TrackedAsset(component.asset.clone()))
+        {
+            return Err(ContractError::AssetNotFound);
+        }
+
+        if component.weight == 0 {
+            return Err(ContractError::InvalidWeight);
+        }
+
+        let price_data = crate::PriceOracle::get_price(env.clone(), component.asset.clone(), true)?;
+        let weight_i128: i128 = component.weight.into();
+        let weighted_val = price_data
+            .price
+            .checked_mul(weight_i128)
+            .ok_or(ContractError::InvalidPrice)?;
+
+        total_weighted_price = total_weighted_price
+            .checked_add(weighted_val)
+            .ok_or(ContractError::InvalidPrice)?;
+
+        total_weight = total_weight
+            .checked_add(component.weight)
+            .unwrap_or(total_weight);
+    }
+
+    if total_weight == 0 {
+        return Err(ContractError::InvalidWeight);
+    }
+
+    total_weighted_price
+        .checked_div(total_weight as i128)
+        .ok_or(ContractError::PriceMathOverflow)
+}
+
+/// Remove a batch of price entries without copying the input vector.
+pub fn clear_assets(env: &Env, assets: &Vec<Symbol>) -> Result<(), ContractError> {
+    if assets.len() > MAX_CLEAR_ASSETS {
+        return Err(ContractError::TooManyAssets);
+    }
+
+    let storage = env.storage().persistent();
+    for asset in assets.iter() {
+        storage.remove(&DataKey::Price(asset));
+    }
+
+    Ok(())
+}


### PR DESCRIPTION
## Summary
closes #448 
- Add `contracts/price-oracle/src/validation.rs` for borrowed, vector-heavy helpers
- Delegate `get_index_price`, `register_assets_with_config`, and `clear_assets` to shared-reference helpers
- Repair two preexisting parse breaks that blocked formatting and parsing

## Validation
- `rustfmt --edition 2021 --check contracts/price-oracle/src/validation.rs`
- `cargo test -p price-oracle --lib` blocked by preexisting repo issues unrelated to this refactor