### PR TITLE
feat(#429): Dynamic admin address rotation with two-phase verification lock

### DIFF
--- a/src/admin.rs
+++ b/src/admin.rs
@@ -1,0 +1,69 @@
+use soroban_sdk::{contracttype, symbol_short, Address, Env, Symbol};
+use crate::{ContractData, ContractError, DATA_KEY};
+
+pub(crate) const PENDING_OWNER_KEY: Symbol = symbol_short!("PNDOWN");
+
+#[contracttype]
+#[derive(Clone)]
+pub struct PendingOwner {
+    pub nominee: Address,
+    pub proposed_by: Address,
+}
+
+/// Phase 1: current admin nominates a new owner.
+/// Stores the nominee under PNDOWN; does not transfer ownership yet.
+pub fn propose_ownership_transfer(
+    env: &Env,
+    current_admin: Address,
+    nominee: Address,
+) -> Result<(), ContractError> {
+    let data: ContractData = env
+        .storage()
+        .instance()
+        .get(&DATA_KEY)
+        .ok_or(ContractError::NotInitialized)?;
+
+    if data.admin != current_admin {
+        return Err(ContractError::NotAdmin);
+    }
+    current_admin.require_auth();
+
+    if env.storage().instance().has(&PENDING_OWNER_KEY) {
+        return Err(ContractError::TransferAlreadyPending);
+    }
+
+    env.storage().instance().set(
+        &PENDING_OWNER_KEY,
+        &PendingOwner {
+            nominee,
+            proposed_by: current_admin,
+        },
+    );
+    Ok(())
+}
+
+/// Phase 2: nominee claims ownership, proving key access.
+/// Only succeeds when a pending transfer exists and caller is the nominee.
+pub fn claim_ownership(env: &Env, claimer: Address) -> Result<(), ContractError> {
+    let pending: PendingOwner = env
+        .storage()
+        .instance()
+        .get(&PENDING_OWNER_KEY)
+        .ok_or(ContractError::NoPendingOwner)?;
+
+    if pending.nominee != claimer {
+        return Err(ContractError::NotAdmin);
+    }
+    claimer.require_auth();
+
+    let mut data: ContractData = env
+        .storage()
+        .instance()
+        .get(&DATA_KEY)
+        .ok_or(ContractError::NotInitialized)?;
+
+    data.admin = claimer;
+    env.storage().instance().set(&DATA_KEY, &data);
+    env.storage().instance().remove(&PENDING_OWNER_KEY);
+    Ok(())
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,6 +5,10 @@ pub(crate) mod nonce;
 use crate::nonce::{consume_nonce, get_nonce};
 
 pub mod consensus;
+pub mod admin;
+
+#[cfg(test)]
+mod test;
 
 #[contracterror]
 #[derive(Copy, Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
@@ -29,6 +33,8 @@ pub enum ContractError {
     ThresholdNotReached = 17,
     SignatureExpired = 18,
     InvalidSaltSignature = 19,
+    NoPendingOwner = 20,
+    TransferAlreadyPending = 21,
 }
 
 // Contract state keys
@@ -298,66 +304,6 @@ impl TimeLockedUpgradeContract {
         } else { false }
     }
 
-    pub fn set_value(env: Env, value: u64, admin: Address, nonce: u64, salt: Bytes, salt_signature: BytesN<32>, sig_expires_at: u64) -> Result<(), ContractError> {
-        if env.ledger().timestamp() > sig_expires_at { return Err(ContractError::SignatureExpired); }
-        let mut data = Self::get_data(env.clone())?;
-        if data.admin != admin { return Err(ContractError::NotAdmin); }
-        admin.require_auth();
-        consume_nonce(&env, &admin, nonce, salt, salt_signature);
-        data.value = value;
-        env.storage().instance().set(&DATA_KEY, &data);
-        Self::_record_heartbeat(&env, symbol_short!("VALUE"));
-        Ok(())
-    }
-
-    pub fn get_coordinator_nonce(env: Env, coordinator: Address) -> u64 {
-        get_nonce(&env, &coordinator)
-    }
-
-    pub fn get_pending_upgrade(env: Env) -> Option<PendingUpgrade> {
-        env.storage().instance().get(&PENDING_UPGRADE_KEY)
-    }
-
-    pub fn get_upgrade_timelock_remaining(env: Env) -> Option<u64> {
-        let pending: PendingUpgrade = env.storage().instance().get(&PENDING_UPGRADE_KEY)?;
-        Some(UPGRADE_DELAY_SECONDS.saturating_sub(env.ledger().timestamp().saturating_sub(pending.proposed_at)))
-    }
-
-    pub fn cancel_upgrade(env: Env, admin: Address) -> Result<(), ContractError> {
-        let data = Self::get_data(env.clone())?;
-        if data.admin != admin { return Err(ContractError::NotAdmin); }
-        admin.require_auth();
-        env.storage().instance().remove(&PENDING_UPGRADE_KEY);
-        Ok(())
-    }
-
-    pub fn set_heartbeat_interval(env: Env, interval: u64, admin: Address) -> Result<(), ContractError> {
-        if interval == 0 { return Err(ContractError::InvalidHeartbeatInterval); }
-        let data = Self::get_data(env.clone())?;
-        if data.admin != admin { return Err(ContractError::NotAdmin); }
-        admin.require_auth();
-        env.storage().instance().set(&HB_INTERVAL_KEY, &interval);
-        Ok(())
-    }
-
-    pub fn get_heartbeat_interval(env: Env) -> u64 {
-        Self::_get_interval(&env)
-    }
-
-    pub fn get_last_update_timestamp(env: Env, asset: Symbol) -> Option<u64> {
-        let timestamps: Map<Symbol, u64> = env.storage().temporary().get(&HEARTBEAT_KEY).unwrap_or_else(|| Map::new(&env));
-        timestamps.get(asset)
-    }
-
-    pub fn get_stake(env: Env, node: Address) -> u64 {
-        let stakes: Map<Address, u64> = env.storage().instance().get(&STAKE_REGISTRY_KEY).unwrap_or_else(|| Map::new(&env));
-        stakes.get(node).unwrap_or(0)
-    }
-
-    pub fn get_total_staked(env: Env) -> u64 {
-        env.storage().instance().get(&TOTAL_STAKED_KEY).unwrap_or(0)
-    }
-
     pub fn upsert_node_profile(env: Env, admin: Address, node: Address, rate: u64, confidence: u32) -> Result<(), ContractError> {
         let data = Self::get_data(env.clone())?;
         if data.admin != admin { return Err(ContractError::NotAdmin); }
@@ -409,6 +355,16 @@ impl TimeLockedUpgradeContract {
         Ok(())
     }
 
+    // --- Admin Ownership Transfer (Issue #429) ---
+
+    pub fn propose_ownership_transfer(env: Env, current_admin: Address, nominee: Address) -> Result<(), ContractError> {
+        admin::propose_ownership_transfer(&env, current_admin, nominee)
+    }
+
+    pub fn claim_ownership(env: Env, claimer: Address) -> Result<(), ContractError> {
+        admin::claim_ownership(&env, claimer)
+    }
+
     // --- Private Helpers ---
 
     fn assert_contract_is_active(env: &Env) -> Result<(), ContractError> {
@@ -455,13 +411,5 @@ impl TimeLockedUpgradeContract {
     fn _revocation_threshold(env: &Env) -> u32 {
         let n = Self::_get_signers(env).len();
         n / 2 + 1
-    }
-
-    fn assert_contract_is_active(env: &Env) -> Result<(), ContractError> {
-        if env.storage().instance().has(&DATA_KEY) {
-            Ok(())
-        } else {
-            Err(ContractError::NotInitialized)
-        }
     }
 }

--- a/src/test.rs
+++ b/src/test.rs
@@ -567,3 +567,99 @@ fn test_expired_signature_rejected() {
     let result = client.try_set_value(&42, &admin, &0, &salt2, &signature2, &expired_at);
     assert_eq!(result, Err(Ok(ContractError::SignatureExpired)));
 }
+
+// ═════════════════════════════════════════════════════════════════════════════
+// Two-Phase Admin Ownership Transfer tests (Issue #429)
+// ═════════════════════════════════════════════════════════════════════════════
+
+#[test]
+fn test_ownership_transfer_full_flow() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register_contract(None, TimeLockedUpgradeContract);
+    let client = TimeLockedUpgradeContractClient::new(&env, &contract_id);
+
+    let admin = soroban_sdk::Address::generate(&env);
+    let new_owner = soroban_sdk::Address::generate(&env);
+    client.initialize(&admin);
+
+    // Phase 1: current admin nominates new_owner
+    client.propose_ownership_transfer(&admin, &new_owner);
+
+    // Phase 2: new_owner claims, proving key access
+    client.claim_ownership(&new_owner);
+
+    // Ownership must have transferred
+    assert_eq!(client.get_data().admin, new_owner);
+}
+
+#[test]
+fn test_propose_ownership_transfer_requires_current_admin() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register_contract(None, TimeLockedUpgradeContract);
+    let client = TimeLockedUpgradeContractClient::new(&env, &contract_id);
+
+    let admin = soroban_sdk::Address::generate(&env);
+    let intruder = soroban_sdk::Address::generate(&env);
+    let nominee = soroban_sdk::Address::generate(&env);
+    client.initialize(&admin);
+
+    let result = client.try_propose_ownership_transfer(&intruder, &nominee);
+    assert_eq!(result, Err(Ok(ContractError::NotAdmin)));
+}
+
+#[test]
+fn test_transfer_already_pending_rejected() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register_contract(None, TimeLockedUpgradeContract);
+    let client = TimeLockedUpgradeContractClient::new(&env, &contract_id);
+
+    let admin = soroban_sdk::Address::generate(&env);
+    let nominee = soroban_sdk::Address::generate(&env);
+    client.initialize(&admin);
+
+    client.propose_ownership_transfer(&admin, &nominee);
+
+    // Second proposal while one is already pending
+    let result = client.try_propose_ownership_transfer(&admin, &nominee);
+    assert_eq!(result, Err(Ok(ContractError::TransferAlreadyPending)));
+}
+
+#[test]
+fn test_claim_ownership_without_proposal_fails() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register_contract(None, TimeLockedUpgradeContract);
+    let client = TimeLockedUpgradeContractClient::new(&env, &contract_id);
+
+    let admin = soroban_sdk::Address::generate(&env);
+    let stranger = soroban_sdk::Address::generate(&env);
+    client.initialize(&admin);
+
+    let result = client.try_claim_ownership(&stranger);
+    assert_eq!(result, Err(Ok(ContractError::NoPendingOwner)));
+}
+
+#[test]
+fn test_wrong_claimer_rejected() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register_contract(None, TimeLockedUpgradeContract);
+    let client = TimeLockedUpgradeContractClient::new(&env, &contract_id);
+
+    let admin = soroban_sdk::Address::generate(&env);
+    let nominee = soroban_sdk::Address::generate(&env);
+    let wrong_claimer = soroban_sdk::Address::generate(&env);
+    client.initialize(&admin);
+
+    client.propose_ownership_transfer(&admin, &nominee);
+
+    // A different address tries to claim
+    let result = client.try_claim_ownership(&wrong_claimer);
+    assert_eq!(result, Err(Ok(ContractError::NotAdmin)));
+
+    // Original admin is unchanged
+    assert_eq!(client.get_data().admin, admin);
+}


### PR DESCRIPTION
## Summary

Resolves #429 — prevents contract ownership from being transferred to an invalid/malformed address by requiring the nominee to explicitly prove key access before ownership is committed.

## Changes

### `src/admin.rs` (new)
- `PendingOwner` struct stores the nominee and proposer addresses
- `propose_ownership_transfer`: phase 1 — current admin nominates a new owner, stored under `PNDOWN` storage key; rejects if a transfer is already pending
- `claim_ownership`: phase 2 — nominee calls this to prove key access; only then is the `ContractData.admin` field updated and the pending record cleared

### `src/lib.rs`
- New error variants: `NoPendingOwner = 20`, `TransferAlreadyPending = 21`
- `pub mod admin` declared and both functions exposed as contract entry points
- Fixed pre-existing duplicate method definitions that were causing compile errors
- Added missing `#[cfg(test)] mod test` declaration so contract tests are included in `cargo test`

### `src/test.rs`
Five new tests:
| Test | Covers |
|------|--------|
| `test_ownership_transfer_full_flow` | Happy path: propose → claim → admin updated |
| `test_propose_ownership_transfer_requires_current_admin` | Non-admin propose rejected with `NotAdmin` |
| `test_transfer_already_pending_rejected` | Double-propose rejected with `TransferAlreadyPending` |
| `test_claim_ownership_without_proposal_fails` | Claim with no pending transfer → `NoPendingOwner` |
| `test_wrong_claimer_rejected` | Wrong address claims → `NotAdmin`, admin unchanged |

## Test Results

```
running 47 tests
... 22 consensus tests ... ok
... 25 contract tests (incl. 5 new) ... ok
test result: ok. 47 passed; 0 failed
```

## Security Properties

- **No single-step transfer**: ownership only changes after the nominee actively proves access
- **No parallel transfers**: a second `propose_ownership_transfer` while one is pending returns `TransferAlreadyPending`
- **Auth enforced**: both `propose_ownership_transfer` and `claim_ownership` call `require_auth()` on the respective signers