### PR TITLE
Integer squaring tracking 416

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -49,6 +49,7 @@ pub(crate) mod nonce;
 use crate::nonce::{consume_nonce, get_nonce};
 
 pub mod consensus;
+pub mod math;
 pub mod staking_tiers;
 pub mod governance;
 use crate::governance::{verify_staged_delay, StagedUpgrade};

--- a/src/math.rs
+++ b/src/math.rs
@@ -1,0 +1,235 @@
+//! Integer-precision variance tracking for cross-border corridor rates.
+//!
+//! All arithmetic enforces strict integer-only multiplication before
+//! scale-down division passes to preserve calculation precision and
+//! prevent rounding distortions.
+
+use crate::ContractError;
+
+/// Compute the checked sum of a slice of `i128` values.
+///
+/// Returns `ContractError::Overflow` if any intermediate addition
+/// exceeds `i128::MAX`.
+pub fn compute_sum(values: &[i128]) -> Result<i128, ContractError> {
+    values
+        .iter()
+        .try_fold(0_i128, |acc, &v| acc.checked_add(v).ok_or(ContractError::Overflow))
+}
+
+/// Compute the integer arithmetic mean (floor) of a slice of `i128` values.
+///
+/// Returns `0` for an empty slice.  The mean is truncated toward zero,
+/// which is acceptable for downstream variance computation since the
+/// squared-deviation pass operates on exact deltas.
+pub fn compute_mean(values: &[i128]) -> Result<i128, ContractError> {
+    let n = values.len();
+    if n == 0 {
+        return Ok(0);
+    }
+    let sum = compute_sum(values)?;
+    Ok(sum / n as i128)
+}
+
+/// Compute the sum of squared deviations from a pre-computed mean.
+///
+/// Each deviation `(value - mean)` is squared **before** any scaling
+/// or division, preserving all bit-width precision until the final
+/// variance pass.  All intermediate operations use checked arithmetic.
+pub fn compute_sum_squared_deviations(values: &[i128], mean: i128) -> Result<i128, ContractError> {
+    values.iter().try_fold(0_i128, |acc, &v| {
+        let dev = v - mean;
+        let sq = dev.checked_mul(dev).ok_or(ContractError::Overflow)?;
+        acc.checked_add(sq).ok_or(ContractError::Overflow)
+    })
+}
+
+/// Compute the **population** variance of a sample set.
+///
+/// Formula: `sum((value - mean)²) / n`
+///
+/// Squared deviations are accumulated in full precision (multiplication
+/// first, division last).  Returns `0` for slices with fewer than 2
+/// elements.
+pub fn compute_population_variance(values: &[i128]) -> Result<i128, ContractError> {
+    let n = values.len();
+    if n <= 1 {
+        return Ok(0);
+    }
+    let mean = compute_mean(values)?;
+    let sum_sq = compute_sum_squared_deviations(values, mean)?;
+    Ok(sum_sq / n as i128)
+}
+
+/// Compute the **sample** (unbiased) variance of a sample set.
+///
+/// Formula: `sum((value - mean)²) / (n - 1)`
+///
+/// Squared deviations are accumulated in full precision (multiplication
+/// first, division last).  Returns `0` for slices with fewer than 2
+/// elements.
+pub fn compute_sample_variance(values: &[i128]) -> Result<i128, ContractError> {
+    let n = values.len();
+    if n <= 1 {
+        return Ok(0);
+    }
+    let mean = compute_mean(values)?;
+    let sum_sq = compute_sum_squared_deviations(values, mean)?;
+    Ok(sum_sq / (n - 1) as i128)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // --- compute_sum ---
+
+    #[test]
+    fn test_sum_empty() {
+        assert_eq!(compute_sum(&[]), Ok(0));
+    }
+
+    #[test]
+    fn test_sum_single() {
+        assert_eq!(compute_sum(&[42]), Ok(42));
+    }
+
+    #[test]
+    fn test_sum_multiple() {
+        assert_eq!(compute_sum(&[10, 20, 30]), Ok(60));
+    }
+
+    #[test]
+    fn test_sum_overflow() {
+        assert_eq!(
+            compute_sum(&[i128::MAX, 1]),
+            Err(ContractError::Overflow)
+        );
+    }
+
+    // --- compute_mean ---
+
+    #[test]
+    fn test_mean_empty() {
+        assert_eq!(compute_mean(&[]), Ok(0));
+    }
+
+    #[test]
+    fn test_mean_single() {
+        assert_eq!(compute_mean(&[100]), Ok(100));
+    }
+
+    #[test]
+    fn test_mean_truncates_toward_zero() {
+        assert_eq!(compute_mean(&[10, 20, 30, 41]), Ok(25));
+    }
+
+    #[test]
+    fn test_mean_exact() {
+        assert_eq!(compute_mean(&[1_000, 2_000, 3_000]), Ok(2_000));
+    }
+
+    // --- compute_sum_squared_deviations ---
+
+    #[test]
+    fn test_sum_sq_all_at_mean() {
+        let values = &[5, 5, 5];
+        assert_eq!(compute_sum_squared_deviations(values, 5), Ok(0));
+    }
+
+    #[test]
+    fn test_sum_sq_known() {
+        let values = &[1, 2, 3, 4, 5];
+        let mean = compute_mean(values).unwrap();
+        assert_eq!(mean, 3);
+        let sum_sq = compute_sum_squared_deviations(values, mean).unwrap();
+        // (1-3)² + (2-3)² + (3-3)² + (4-3)² + (5-3)² = 4 + 1 + 0 + 1 + 4 = 10
+        assert_eq!(sum_sq, 10);
+    }
+
+    #[test]
+    fn test_sum_sq_overflow() {
+        let values = &[i128::MAX, 0];
+        assert_eq!(
+            compute_sum_squared_deviations(values, 0),
+            Err(ContractError::Overflow)
+        );
+    }
+
+    // --- compute_population_variance ---
+
+    #[test]
+    fn test_pop_variance_empty() {
+        assert_eq!(compute_population_variance(&[]), Ok(0));
+    }
+
+    #[test]
+    fn test_pop_variance_single() {
+        assert_eq!(compute_population_variance(&[100]), Ok(0));
+    }
+
+    #[test]
+    fn test_pop_variance_identical() {
+        assert_eq!(compute_population_variance(&[7, 7, 7, 7]), Ok(0));
+    }
+
+    #[test]
+    fn test_pop_variance_known() {
+        let values = &[1, 2, 3, 4, 5];
+        let var = compute_population_variance(values).unwrap();
+        // population variance of [1,2,3,4,5] = 10 / 5 = 2
+        assert_eq!(var, 2);
+    }
+
+    #[test]
+    fn test_pop_variance_two_elements() {
+        let values = &[10, 20];
+        let var = compute_population_variance(values).unwrap();
+        // mean = 15, devs: -5, 5; sq devs: 25, 25; sum_sq = 50; var = 50/2 = 25
+        assert_eq!(var, 25);
+    }
+
+    // --- compute_sample_variance ---
+
+    #[test]
+    fn test_sample_variance_empty() {
+        assert_eq!(compute_sample_variance(&[]), Ok(0));
+    }
+
+    #[test]
+    fn test_sample_variance_single() {
+        assert_eq!(compute_sample_variance(&[100]), Ok(0));
+    }
+
+    #[test]
+    fn test_sample_variance_identical() {
+        assert_eq!(compute_sample_variance(&[7, 7, 7, 7]), Ok(0));
+    }
+
+    #[test]
+    fn test_sample_variance_known() {
+        let values = &[1, 2, 3, 4, 5];
+        let var = compute_sample_variance(values).unwrap();
+        // sample variance of [1,2,3,4,5] = 10 / 4 = 2 (integer floor)
+        assert_eq!(var, 2);
+    }
+
+    #[test]
+    fn test_sample_variance_two_elements() {
+        let values = &[10, 20];
+        let var = compute_sample_variance(values).unwrap();
+        // mean = 15, devs: -5, 5; sq devs: 25, 25; sum_sq = 50; var = 50/1 = 50
+        assert_eq!(var, 50);
+    }
+
+    // --- corridor-rate scenario ---
+
+    #[test]
+    fn test_corridor_rate_variance_preserves_precision() {
+        // Simulate five corridor rate submissions around 1.05 (scaled to 7 decimals)
+        let rates = &[10_500_000, 10_510_000, 10_490_000, 10_505_000, 10_495_000];
+        let var = compute_population_variance(rates).unwrap();
+        // Every product (dev * dev) is done in full i128 before division,
+        // so no fractional bits are lost before the final scale-down.
+        assert!(var > 0);
+    }
+}


### PR DESCRIPTION
### Summary

Closes #416 

Implements an optimized variance computing helper inside `src/math.rs` that enforces strict integer-only multiplication before scale-down division to preserve calculation precision when tracking deviations across cross-border corridor rates.

### Motivation

Calculating statistical data deviations across corridor rates can introduce rounding distortions if fractional variables drop bits during division. By deferring all division until after multiplication, the full bit-width of each squared deviation is preserved.

### Changes

**`src/math.rs` [NEW]**
- `compute_sum` — checked sum of `i128` values.
- `compute_mean` — integer arithmetic mean (floor).
- `compute_sum_squared_deviations` — core helper that squares each deviation via `checked_mul` **before** any division, preserving full `i128` precision.
- `compute_population_variance` — `sum((x-mean)²) / n` (multiplication-first, division-last).
- `compute_sample_variance` — `sum((x-mean)²) / (n-1)` (same precision-preserving pattern).
- Unit tests for all functions including empty/single/multiple inputs, overflow edge cases, and a corridor-rate precision scenario.

**`src/lib.rs`**
- Added `pub mod math;` to register the module.

### Testing

```bash
cargo test
# all tests pass
```
