### PR TITLE
Memory-Sanitization | Stack-Allocated Buffers for Fast Median Rate Sorting

### DIFF
--- a/contracts/price-oracle/src/median.rs
+++ b/contracts/price-oracle/src/median.rs
@@ -1,5 +1,11 @@
 use soroban_sdk::{contracterror, Vec};
 
+/// Hard cap matching the on-chain `MAX_MEDIAN_ENTRIES` constant (11) with
+/// headroom for future validator-set growth.  All sorting is done inside a
+/// stack buffer of exactly this size — no heap allocation occurs during the
+/// median computation.
+pub const MAX_VALIDATORS: usize = 15;
+
 #[contracterror]
 #[derive(Copy, Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
 #[repr(u32)]
@@ -7,59 +13,99 @@ pub enum MedianError {
     EmptyInput = 10,
     /// Arithmetic operation overflow detected.
     ArithmeticOverflow = 11,
+    /// Input length exceeds the static stack-buffer capacity (MAX_VALIDATORS).
+    InputTooLarge = 12,
 }
 
-/// Sort a Vec<i128> using insertion sort (no_std compatible).
-#[allow(dead_code)]
-fn sort_prices(prices: &mut Vec<i128>) {
-    let len = prices.len();
+// ── Stack-only sort helpers ────────────────────────────────────────────────
+
+/// Insertion sort on a primitive `i128` slice — all work stays on the stack.
+///
+/// Insertion sort is chosen over quicksort because:
+///  - No recursion (no hidden stack frames beyond the single call frame).
+///  - O(n) best-case on already-sorted input (common for sequential relayer feeds).
+///  - Negligible overhead for the small n ≤ MAX_VALIDATORS bound.
+#[inline]
+fn sort_stack_i128(buf: &mut [i128], len: usize) {
     for i in 1..len {
+        let key = buf[i];
         let mut j = i;
-        while j > 0 {
-            let a = prices.get(j - 1).unwrap();
-            let b = prices.get(j).unwrap();
-            if a > b {
-                prices.set(j - 1, b);
-                prices.set(j, a);
-                j -= 1;
-            } else {
-                break;
-            }
+        // Shift elements greater than `key` one position to the right.
+        while j > 0 && buf[j - 1] > key {
+            buf[j] = buf[j - 1];
+            j -= 1;
         }
+        buf[j] = key;
     }
 }
 
+/// Insertion sort on the value component of `(i128, u32)` pairs stored in a
+/// primitive stack array — all work stays on the stack.
+#[inline]
+fn sort_stack_pairs(buf: &mut [(i128, u32)], len: usize) {
+    for i in 1..len {
+        let key = buf[i];
+        let mut j = i;
+        while j > 0 && buf[j - 1].0 > key.0 {
+            buf[j] = buf[j - 1];
+            j -= 1;
+        }
+        buf[j] = key;
+    }
+}
+
+// ── Public median functions ────────────────────────────────────────────────
+
 /// Returns the median of the provided prices.
-/// - 0 inputs  → Err(MedianError::EmptyInput)
-/// - 1 input   → returns that value
-/// - odd count → returns the middle value
-/// - even count → returns the average of the two middle values
+///
+/// # Gas profile
+/// The Soroban `Vec` is traversed once to copy values into a
+/// stack-allocated `[i128; MAX_VALIDATORS]` buffer.  All sorting and index
+/// arithmetic are then performed entirely in stack memory — no further host
+/// object calls are made after the copy step.
+///
+/// # Errors
+/// - [`MedianError::EmptyInput`]     — slice is empty.
+/// - [`MedianError::InputTooLarge`]  — more than `MAX_VALIDATORS` entries.
+/// - [`MedianError::ArithmeticOverflow`] — even-count average overflows `i128`.
 #[allow(dead_code)]
-pub fn calculate_median(mut prices: Vec<i128>) -> Result<i128, MedianError> {
-    let len = prices.len();
+pub fn calculate_median(prices: Vec<i128>) -> Result<i128, MedianError> {
+    let len = prices.len() as usize;
     if len == 0 {
         return Err(MedianError::EmptyInput);
     }
-    sort_prices(&mut prices);
+    if len > MAX_VALIDATORS {
+        return Err(MedianError::InputTooLarge);
+    }
+
+    // Copy host-side Vec into a stack-allocated primitive array in one pass.
+    let mut buf = [0i128; MAX_VALIDATORS];
+    for i in 0..len {
+        buf[i] = prices.get(i as u32).unwrap();
+    }
+
+    // Sort entirely on the stack — zero host allocations.
+    sort_stack_i128(&mut buf, len);
+
     let mid = len / 2;
     if len % 2 == 1 {
-        Ok(prices.get(mid).unwrap())
+        Ok(buf[mid])
     } else {
-        let lo = prices.get(mid - 1).unwrap();
-        let hi = prices.get(mid).unwrap();
-        let sum = lo.checked_add(hi).ok_or(MedianError::ArithmeticOverflow)?;
-        Ok(sum.checked_div(2).ok_or(MedianError::ArithmeticOverflow)?)
+        let sum = buf[mid - 1]
+            .checked_add(buf[mid])
+            .ok_or(MedianError::ArithmeticOverflow)?;
+        sum.checked_div(2).ok_or(MedianError::ArithmeticOverflow)
     }
 }
 
 /// Value at multiset index `target` (0-based) in an ascending `(value, count)`
-/// vector, located via cumulative counts.
-fn value_at(pairs: &Vec<(i128, u32)>, target: u64) -> i128 {
-    let len = pairs.len();
+/// stack buffer, located via cumulative counts.
+#[inline]
+fn value_at_stack(buf: &[(i128, u32)], len: usize, target: u64) -> i128 {
     let mut cum: u64 = 0;
     let mut last: i128 = 0;
     for i in 0..len {
-        let (v, c) = pairs.get(i).unwrap();
+        let (v, c) = buf[i];
         last = v;
         cum += c as u64;
         if target < cum {
@@ -72,21 +118,36 @@ fn value_at(pairs: &Vec<(i128, u32)>, target: u64) -> i128 {
 
 /// Median of a multiset represented as compacted `(value, count)` pairs.
 ///
-/// The insertion sort below runs only over the DISTINCT values, while `count`
-/// preserves each value's true multiplicity. The result is therefore identical
-/// to sorting the full expanded multiset — this is the gas saving from
-/// "vector compacting" without altering the consensus median.
+/// The insertion sort runs only over the DISTINCT values (up to `MAX_VALIDATORS`
+/// distinct prices), while `count` preserves each value's true multiplicity.
+/// The result is therefore identical to sorting the full expanded multiset.
+///
+/// # Gas profile
+/// The Soroban `Vec` is traversed once to copy `(i128, u32)` pairs into a
+/// stack-allocated `[(i128, u32); MAX_VALIDATORS]` buffer.  All subsequent
+/// sorting, cumulative-count traversal, and index arithmetic run on the stack.
+///
+/// # Errors
+/// - [`MedianError::EmptyInput`]     — zero pairs or all counts are zero.
+/// - [`MedianError::InputTooLarge`]  — more than `MAX_VALIDATORS` distinct values.
+/// - [`MedianError::ArithmeticOverflow`] — count sum or average overflows.
 #[allow(dead_code)]
-pub fn calculate_median_compacted(mut pairs: Vec<(i128, u32)>) -> Result<i128, MedianError> {
-    let len = pairs.len();
+pub fn calculate_median_compacted(pairs: Vec<(i128, u32)>) -> Result<i128, MedianError> {
+    let len = pairs.len() as usize;
     if len == 0 {
         return Err(MedianError::EmptyInput);
     }
+    if len > MAX_VALIDATORS {
+        return Err(MedianError::InputTooLarge);
+    }
 
-    // Total number of original rows across all buckets.
+    // Copy host-side Vec into a stack-allocated primitive array in one pass,
+    // accumulating the total count at the same time.
+    let mut buf = [(0i128, 0u32); MAX_VALIDATORS];
     let mut total: u64 = 0;
     for i in 0..len {
-        let (_, c) = pairs.get(i).unwrap();
+        let (v, c) = pairs.get(i as u32).unwrap();
+        buf[i] = (v, c);
         total = total
             .checked_add(c as u64)
             .ok_or(MedianError::ArithmeticOverflow)?;
@@ -95,31 +156,18 @@ pub fn calculate_median_compacted(mut pairs: Vec<(i128, u32)>) -> Result<i128, M
         return Err(MedianError::EmptyInput);
     }
 
-    // Insertion sort over DISTINCT values only (ascending by value).
-    for i in 1..len {
-        let mut j = i;
-        while j > 0 {
-            let (va, _) = pairs.get(j - 1).unwrap();
-            let (vb, _) = pairs.get(j).unwrap();
-            if va > vb {
-                let a = pairs.get(j - 1).unwrap();
-                let b = pairs.get(j).unwrap();
-                pairs.set(j - 1, b);
-                pairs.set(j, a);
-                j -= 1;
-            } else {
-                break;
-            }
-        }
-    }
+    // Sort distinct values entirely on the stack — zero host allocations.
+    sort_stack_pairs(&mut buf, len);
 
     if total % 2 == 1 {
-        Ok(value_at(&pairs, total / 2))
+        Ok(value_at_stack(&buf, len, total / 2))
     } else {
-        let lo = value_at(&pairs, total / 2 - 1);
-        let hi = value_at(&pairs, total / 2);
-        let sum = lo.checked_add(hi).ok_or(MedianError::ArithmeticOverflow)?;
-        Ok(sum.checked_div(2).ok_or(MedianError::ArithmeticOverflow)?)
+        let lo = value_at_stack(&buf, len, total / 2 - 1);
+        let hi = value_at_stack(&buf, len, total / 2);
+        let sum = lo
+            .checked_add(hi)
+            .ok_or(MedianError::ArithmeticOverflow)?;
+        sum.checked_div(2).ok_or(MedianError::ArithmeticOverflow)
     }
 }
 
@@ -154,6 +202,17 @@ mod median_tests {
         let env = Env::default();
         let prices = soroban_sdk::Vec::<i128>::new(&env);
         assert_eq!(calculate_median(prices), Err(MedianError::EmptyInput));
+    }
+
+    #[test]
+    fn test_input_too_large_returns_error() {
+        let env = Env::default();
+        // 16 entries exceeds MAX_VALIDATORS (15).
+        let prices = vec![
+            &env,
+            1_i128, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16,
+        ];
+        assert_eq!(calculate_median(prices), Err(MedianError::InputTooLarge));
     }
 
     #[test]
@@ -195,6 +254,21 @@ mod median_tests {
         assert_eq!(
             crate::median::calculate_median_compacted(pairs),
             Err(MedianError::EmptyInput)
+        );
+    }
+
+    #[test]
+    fn test_compacted_too_large_returns_error() {
+        use crate::median::MAX_VALIDATORS;
+        let env = Env::default();
+        // Build a pairs Vec with MAX_VALIDATORS + 1 distinct entries.
+        let mut pairs = soroban_sdk::Vec::<(i128, u32)>::new(&env);
+        for i in 0..=(MAX_VALIDATORS as i128) {
+            pairs.push_back((i * 100, 1_u32));
+        }
+        assert_eq!(
+            crate::median::calculate_median_compacted(pairs),
+            Err(MedianError::InputTooLarge)
         );
     }
 }


### PR DESCRIPTION
closes #492 

changes implemented in median.rs

The old code used soroban_sdk::Vec as both the input container and the sort buffer. Every prices.get(i), prices.set(i, v) call during the insertion sort crossed the Soroban host boundary — each crossing burns computation gas. With 11 entries that's up to ~55 host reads + ~55 host writes just for the sort.

The new code:

Declares a fixed-size stack array ([i128; MAX_VALIDATORS] = [i128; 15], and [(i128, u32); MAX_VALIDATORS] for the compacted path).
Copies the Soroban Vec into the stack buffer in a single sequential pass — the only host-boundary crossings.
All sorting, index arithmetic, and cumulative-count traversal then happen entirely in registers/stack — no host calls at all.
Added MedianError::InputTooLarge = 12 to guard the buffer bound (inputs over 15 distinct prices are rejected rather than silently truncated).
Added two new tests (test_input_too_large_returns_error, test_compacted_too_large_returns_error) covering the new error path.
The sort_prices heap-mutating helper and the value_at host-querying helper are both gone; replaced by sort_stack_i128, sort_stack_pairs, and value_at_stack — all operating on plain Rust slices.
slashing.rs and lib.rs required no changes; their call sites pass Vec<i128> / Vec<(i128, u32)> as before, and the refactored functions accept those same types at the boundary.