### PR TITLE
[codex] Migrate asset identifiers to native symbols

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,53 +5,6 @@ use soroban_sdk::{
     Map, Symbol, Vec,
 };
 
-/// Numeric asset identifier for gas-optimized storage.
-/// Replaces heavy Symbol identifiers in high-frequency paths.
-pub type AssetId = u32;
-
-/// Convert a currency Symbol to a numeric AssetId using FNV-1a hash.
-/// This provides deterministic mapping while minimizing gas costs.
-pub fn symbol_to_asset_id(symbol: &Symbol) -> AssetId {
-    // Simple FNV-1a hash for deterministic conversion
-    let mut hash: u32 = 2166136261u32;
-    // A Symbol is internally a u64, so we can hash its bytes directly
-    // without string allocation.
-    // Convert the symbol to a string, then iterate over its bytes for hashing.
-    // Extract the raw characters from the symbol natively without allocations
-    for character in (*symbol).into_iter() {
-        let byte = character as u8;
-        if byte == 0 { break; } // Symbols are null-padded if shorter than maximum length
-        
-        hash ^= byte as u32; // XOR the byte into the hash
-        hash = hash.wrapping_mul(16777619); // Multiply by FNV prime
-    }
-    hash
-}
-
-/// Convert an AssetId back to a Symbol for backward compatibility.
-/// Note: This is lossy - use pre-defined mappings for production.
-    pub fn asset_id_to_symbol(_env: &Env, id: AssetId) -> Symbol {
-    // For common currencies, use a mapping table
-    match id {
-        // Nigerian Naira
-        3897123275 => symbol_short!("NGN"),
-        // Kenyan Shilling
-        2654435761 => symbol_short!("KES"),
-        // Ghanaian Cedi
-        4026531840 => symbol_short!("GHS"),
-        // West African CFA Franc
-        4160749568 => symbol_short!("CFA"),
-        // South African Rand
-        3219226362 => symbol_short!("ZAR"),
-        // Ugandan Shilling
-        2863311530 => symbol_short!("UGX"),
-        // Special asset identifiers
-        0 => symbol_short!("STAKE"),
-        1 => symbol_short!("VALUE"),
-        _ => symbol_short!("UNK"),
-    }
-}
-
 pub(crate) mod nonce;
 use crate::nonce::{consume_nonce, get_nonce};
 
@@ -227,7 +180,7 @@ impl TimeLockedUpgradeContract {
         stakes.set(node.clone(), amount);
         env.storage().instance().set(&STAKE_REGISTRY_KEY, &stakes);
         env.storage().instance().set(&TOTAL_STAKED_KEY, &new_total);
-        Self::_record_heartbeat(&env, symbol_to_asset_id(&symbol_short!("STAKE")));
+        Self::_record_heartbeat(&env, symbol_short!("STAKE"));
         Ok(StakeRecord { node, amount, registered_at: env.ledger().timestamp() })
     }
 
@@ -350,7 +303,7 @@ impl TimeLockedUpgradeContract {
         env.storage().instance().set(&SEQUENCE_COUNTER_KEY, &seq_map);
         data.value = new_value;
         env.storage().instance().set(&DATA_KEY, &data); // This line was missing a semicolon
-        Self::_record_heartbeat(&env, symbol_to_asset_id(&symbol_short!("VALUE")));
+        Self::_record_heartbeat(&env, symbol_short!("VALUE"));
         Ok(())
     }
 
@@ -394,11 +347,11 @@ impl TimeLockedUpgradeContract {
     ) -> Result<(), ContractError> {
         node.require_auth();
         check_bond_capacity(&env, &node, &pool)?;
-        Self::_record_heartbeat(&env, symbol_to_asset_id(&pool));
+        Self::_record_heartbeat(&env, pool);
         Ok(())
     }
 
-    pub fn update_heartbeat(env: Env, asset: AssetId, updater: Address) -> Result<(), ContractError> {
+    pub fn update_heartbeat(env: Env, asset: Symbol, updater: Address) -> Result<(), ContractError> {
         let data = Self::get_data(env.clone())?;
         if data.admin != updater { return Err(ContractError::NotAdmin); }
         updater.require_auth();
@@ -407,8 +360,8 @@ impl TimeLockedUpgradeContract {
         Ok(())
     }
 
-    pub fn is_data_fresh(env: Env, asset: AssetId) -> bool {
-        let timestamps: Map<AssetId, u64> = env
+    pub fn is_data_fresh(env: Env, asset: Symbol) -> bool {
+        let timestamps: Map<Symbol, u64> = env
             .storage()
             .temporary()
             .get(&HEARTBEAT_KEY)
@@ -763,8 +716,8 @@ impl TimeLockedUpgradeContract {
         Ok(())
     }
 
-    fn _record_heartbeat(env: &Env, asset: AssetId) {
-        let mut timestamps: Map<AssetId, u64> = env.storage().temporary().get(&HEARTBEAT_KEY).unwrap_or_else(|| Map::new(&env));
+    fn _record_heartbeat(env: &Env, asset: Symbol) {
+        let mut timestamps: Map<Symbol, u64> = env.storage().temporary().get(&HEARTBEAT_KEY).unwrap_or_else(|| Map::new(&env));
         timestamps.set(asset, env.ledger().timestamp());
         env.storage().temporary().set(&HEARTBEAT_KEY, &timestamps);
     }
@@ -809,7 +762,7 @@ impl TimeLockedUpgradeContract {
         if n == 0 { 1 } else { n / 2 + 1 }
     }
 
-    fn _resolve_feed_metrics(env: &Env, asset: &AssetId) -> AssetFeedMetrics {
+    fn _resolve_feed_metrics(env: &Env, asset: &Symbol) -> AssetFeedMetrics {
         let pool = Self::get_corridor_fee_pool(env.clone(), asset.clone());
         let stored: AssetFeedMetrics = env
             .storage()

--- a/src/test.rs
+++ b/src/test.rs
@@ -2,8 +2,7 @@ use soroban_sdk::{symbol_short, Bytes, Env};
 use soroban_sdk::testutils::{Address as _, Ledger, LedgerInfo}; // Removed Symbol as _
 use crate::{
     ContractError, StakingTier, StakingTierConfig, TimeLockedUpgradeContract,
-    TimeLockedUpgradeContractClient, DEFAULT_HEARTBEAT_INTERVAL, 
-    AssetId,
+    TimeLockedUpgradeContractClient, DEFAULT_HEARTBEAT_INTERVAL,
 };
 
 /// Helper: advance the ledger timestamp by `delta` seconds.
@@ -193,7 +192,7 @@ fn test_heartbeat_fresh_data() {
     let treasury = soroban_sdk::Address::generate(&env);
     client.initialize(&admin, &treasury);
 
-    let asset: AssetId = 3897123275; // NGN
+    let asset = symbol_short!("NGN");
 
     // Update heartbeat
     client.update_heartbeat(&asset, &admin);
@@ -218,7 +217,7 @@ fn test_heartbeat_stale_data() {
     let treasury = soroban_sdk::Address::generate(&env);
     client.initialize(&admin, &treasury);
 
-    let asset: AssetId = 2654435761; // KES
+    let asset = symbol_short!("KES");
 
     // Update heartbeat at current time
     client.update_heartbeat(&asset, &admin);
@@ -242,7 +241,7 @@ fn test_heartbeat_never_updated() {
     let treasury = soroban_sdk::Address::generate(&env);
     client.initialize(&admin, &treasury);
 
-    let asset: AssetId = 4026531840; // GHS
+    let asset = symbol_short!("GHS");
 
     // No heartbeat recorded → should be stale
     assert!(!client.is_data_fresh(&asset));
@@ -260,7 +259,7 @@ fn test_heartbeat_custom_interval() {
     let treasury = soroban_sdk::Address::generate(&env);
     client.initialize(&admin, &treasury);
 
-    let asset: AssetId = 4160749568; // CFA
+    let asset = symbol_short!("CFA");
 
     // Verify default interval
     assert_eq!(client.get_heartbeat_interval(), DEFAULT_HEARTBEAT_INTERVAL);
@@ -296,7 +295,7 @@ fn test_heartbeat_unauthorized_update() {
     let treasury = soroban_sdk::Address::generate(&env);
     client.initialize(&admin, &treasury);
 
-    let asset: AssetId = 3897123275; // NGN
+    let asset = symbol_short!("NGN");
 
     // Non-admin tries to update heartbeat — should panic
     let args = soroban_sdk::vec![&env, asset.into_val(&env), unauthorized.into_val(&env)];
@@ -416,7 +415,7 @@ fn test_is_data_fresh_does_not_mutate_state() {
     let treasury = soroban_sdk::Address::generate(&env);
     client.initialize(&admin, &treasury);
 
-    let asset: AssetId = 3897123275; // NGN
+    let asset = symbol_short!("NGN");
 
     // Calling is_data_fresh multiple times on the same slot must not alter state
     assert!(!client.is_data_fresh(&asset));
@@ -435,7 +434,7 @@ fn test_query_methods_do_not_affect_each_other() {
     let treasury = soroban_sdk::Address::generate(&env);
     client.initialize(&admin, &treasury);
 
-    let asset: AssetId = 2654435761; // KES
+    let asset = symbol_short!("KES");
 
     // get_data reads contract state; is_data_fresh reads heartbeat storage.
     // Neither should influence the other's result.
@@ -470,7 +469,7 @@ fn test_is_data_fresh_returns_false_for_unknown_asset() {
     client.initialize(&admin, &treasury);
 
     // Any asset that was never written should return false
-    let asset: AssetId = 4026531840; // GHS
+    let asset = symbol_short!("GHS");
     assert!(!client.is_data_fresh(&asset));
 }
 
@@ -510,7 +509,7 @@ fn test_stake_updates_heartbeat() {
     let treasury = soroban_sdk::Address::generate(&env);
     client.initialize(&admin, &treasury);
 
-    let stake_asset: AssetId = 0; // STAKE
+    let stake_asset = symbol_short!("STAKE");
     assert!(!client.is_data_fresh(&stake_asset));
 
     client.stake_and_register(&node, &500u64);
@@ -593,8 +592,8 @@ fn test_regional_feed_allows_lower_stake_than_premier_feed() {
     let treasury = soroban_sdk::Address::generate(&env);
     client.initialize(&admin, &treasury);
 
-    let regional: AssetId = 2654435761; // KES
-    let premier: AssetId = 3897123275; // NGN
+    let regional = symbol_short!("KES");
+    let premier = symbol_short!("NGN");
 
     let signers = soroban_sdk::vec![&env, admin.clone(), admin.clone()];
     client.set_asset_feed_metrics(&admin, &regional, &10, &100, &signers);
@@ -630,7 +629,7 @@ fn test_corridor_volume_bumps_tier_requirements() {
     let treasury = soroban_sdk::Address::generate(&env);
     client.initialize(&admin, &treasury);
 
-    let asset: AssetId = 4026531840; // GHS
+    let asset = symbol_short!("GHS");
     client.set_asset_feed_metrics(&admin, &asset, &10, &200, &soroban_sdk::vec![&env, admin.clone()]);
 
     assert_eq!(client.get_staking_tier(&asset), StakingTier::Regional);
@@ -664,7 +663,7 @@ fn test_custom_tier_config_is_enforced() {
         &signers,
     );
 
-    let asset: AssetId = 3219226362; // ZAR
+    let asset = symbol_short!("ZAR");
     client.set_asset_feed_metrics(&admin, &asset, &10, &100, &signers);
 
     assert_eq!(client.get_required_stake(&asset), 250u64);
@@ -688,7 +687,7 @@ fn test_unstake_from_feed_updates_totals() {
     let treasury = soroban_sdk::Address::generate(&env);
     client.initialize(&admin, &treasury);
 
-    let asset: AssetId = 2863311530; // UGX
+    let asset = symbol_short!("UGX");
     client.set_asset_feed_metrics(&admin, &asset, &10, &100, &soroban_sdk::vec![&env, admin.clone()]);
     client.stake_and_register_for_feed(&node, &asset, &100u64);
 
@@ -709,7 +708,7 @@ fn test_set_value_updates_heartbeat() {
     let treasury = soroban_sdk::Address::generate(&env);
     client.initialize(&admin, &treasury);
 
-    let value_asset: AssetId = 1; // VALUE
+    let value_asset = symbol_short!("VALUE");
 
     // Before set_value, no heartbeat exists for "VALUE"
     assert!(!client.is_data_fresh(&value_asset));
@@ -884,7 +883,7 @@ fn test_update_validator_profile_succeeds_above_min_stake() {
     let pool = symbol_short!("XLM");
     client.update_validator_profile(&node, &pool);
     // Heartbeat for the pool asset should now be fresh.
-    assert!(client.is_data_fresh(&crate::symbol_to_asset_id(&pool)));
+    assert!(client.is_data_fresh(&pool));
 }
 
 // ═════════════════════════════════════════════════════════════════════════════


### PR DESCRIPTION
## Summary

- remove the parallel `u32` `AssetId` representation and lossy hash/mapping helpers
- use Soroban `Symbol` values end to end for heartbeat storage, freshness queries, staking feeds, and corridor asset tracking
- update root-contract tests to exercise native symbols directly

## Why

The root contract mixed numeric asset identifiers with native symbols, forcing conversion work and leaving related APIs on incompatible key types. Using `Symbol` consistently removes that conversion path and keeps asset lookup records compact and native to Soroban.

## Validation

- `git diff --check` passes
- source scan confirms no `AssetId`, `symbol_to_asset_id`, `asset_id_to_symbol`, or string/byte asset containers remain under `src`
- full `cargo fmt --all -- --check` is blocked by pre-existing formatting drift in unrelated workspace contracts
- full `cargo check -p stellarflow-contracts` is blocked by pre-existing syntax errors in `src/lib.rs` and `contracts/price-oracle/src/auth.rs` on `upstream/main`; local Windows linking also lacks `advapi32`, `ole32`, and `oleaut32`

Closes #541
