### PR TITLE
feat: implement emergency halt circuit breaker

### DIFF
--- a/src/admin.rs
+++ b/src/admin.rs
@@ -306,8 +306,15 @@ pub fn set_paused(env: &Env, caller: Address, paused: bool) -> Result<(), Contra
         .get(&DATA_KEY)
         .ok_or(ContractError::NotInitialized)?;
 
-    if data.admin != caller {
-        return Err(ContractError::NotAdmin);
+    let signers: Map<Address, ()> = env
+        .storage()
+        .instance()
+        .get(&SIGNERS_KEY)
+        .unwrap_or_else(|| Map::new(env));
+    let is_signer = signers.contains_key(caller.clone());
+
+    if data.admin != caller && !is_signer {
+        return Err(ContractError::Unauthorized);
     }
     caller.require_auth();
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -341,6 +341,7 @@ impl TimeLockedUpgradeContract {
     }
 
     pub fn set_value(env: Env, new_value: u64, caller: Address, nonce: u64, salt: Bytes, signature: BytesN<32>, sig_expires_at: u64) -> Result<(), ContractError> {
+        Self::assert_contract_is_active(&env)?;
         if env.ledger().timestamp() > sig_expires_at { return Err(ContractError::SignatureExpired); }
         let mut data = Self::get_data(env.clone())?;
         if data.admin != caller { return Err(ContractError::NotAdmin); }
@@ -392,6 +393,7 @@ impl TimeLockedUpgradeContract {
         node: Address,
         pool: Symbol,
     ) -> Result<(), ContractError> {
+        Self::assert_contract_is_active(&env)?;
         node.require_auth();
         check_bond_capacity(&env, &node, &pool)?;
         Self::_record_heartbeat(&env, symbol_to_asset_id(&pool));
@@ -399,6 +401,7 @@ impl TimeLockedUpgradeContract {
     }
 
     pub fn update_heartbeat(env: Env, asset: AssetId, updater: Address) -> Result<(), ContractError> {
+        Self::assert_contract_is_active(&env)?;
         let data = Self::get_data(env.clone())?;
         if data.admin != updater { return Err(ContractError::NotAdmin); }
         updater.require_auth();
@@ -652,9 +655,11 @@ impl TimeLockedUpgradeContract {
         env.storage().instance().set(&PLATFORM_CAPITAL_KEY, &capital);
     }
 
-    pub fn finalize_consensus(env: Env) {
+    pub fn finalize_consensus(env: Env) -> Result<(), ContractError> {
+        Self::assert_contract_is_active(&env)?;
         env.storage().temporary().remove(&CONSENSUS_CACHE_KEY);
         env.storage().temporary().remove(&HEARTBEAT_KEY);
+        Ok(())
     }
 
     pub fn register_signer(env: Env, signer: Address, caller: Address) -> Result<(), ContractError> {

--- a/src/test.rs
+++ b/src/test.rs
@@ -1166,3 +1166,38 @@ fn test_replacement_signer_promoted_on_revocation() {
     let result = client.try_vote_emergency_revocation(&replacement, &u64::MAX);
     assert_eq!(result, Err(Ok(ContractError::NoActiveEmergencyRevocation)));
 }
+
+#[test]
+fn test_emergency_halt_circuit_breaker() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register_contract(None, StellarFlow);
+    let client = StellarFlowClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    let signer_a = Address::generate(&env);
+    
+    client.initialize(&admin);
+    client.register_signer(&signer_a, &admin);
+
+    // Initial state: not paused
+    assert!(!client.is_paused());
+
+    // 1. Signer A (coordinator) can pause the contract
+    client.set_paused(&signer_a, &true);
+    assert!(client.is_paused());
+
+    // 2. Data tracking must halt when paused
+    // update_heartbeat should fail with ContractPaused
+    let heartbeat_result = client.try_update_heartbeat(&0, &admin);
+    assert_eq!(heartbeat_result, Err(Ok(ContractError::ContractPaused)));
+
+    // 3. Admin can unpause the contract
+    client.set_paused(&admin, &false);
+    assert!(!client.is_paused());
+
+    // 4. Random address cannot pause the contract
+    let rando = Address::generate(&env);
+    let pause_result = client.try_set_paused(&rando, &true);
+    assert_eq!(pause_result, Err(Ok(ContractError::Unauthorized)));
+}


### PR DESCRIPTION
Implement the emergency halt circuit-breaker protocol within admin.rs, allowing verified coordinator (signer) addresses or the admin to set the global pause flag. Wired active checks across data tracking/updates paths and added unit tests.

Closes #543