### PR TITLE
feat: enforce WASM binary size limit (<45KB) in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,3 +39,8 @@ jobs:
 
       - name: Build WASM
         run: cargo build --target wasm32-unknown-unknown --release
+
+      - name: Check WASM size
+        run: |
+          chmod +x check_size.sh
+          ./check_size.sh

--- a/check_size.sh
+++ b/check_size.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+set -e
+
+MAX_SIZE=46080 # 45KB in bytes (45 * 1024)
+
+# Find all wasm files in the target directory
+# We exclude files in the build/debug/deps directories
+wasm_files=$(find target/wasm32-unknown-unknown/release -maxdepth 1 -name "*.wasm")
+
+for file in $wasm_files; do
+    size=$(stat -c%s "$file")
+    echo "Checking size of $file: $size bytes"
+    if [ "$size" -gt "$MAX_SIZE" ]; then
+        echo "Error: $file exceeds maximum size of 45KB (found $size bytes)"
+        exit 1
+    fi
+done
+
+echo "All WASM binaries are under 45KB."


### PR DESCRIPTION
Description
  This PR fine-tunes the build pipeline to ensure all compiled contract WASM binaries remain lightweight, specifically
  enforcing a maximum footprint of 45KB per artifact.

  The Cargo.toml release profile was audited to confirm it already utilizes optimal settings for size reduction. To ensure
  these constraints hold throughout development, a CI-based verification step has been added to the build pipeline.

  Changes
   - [x] CI Pipeline: Added check_size.sh script to stellarflow-contracts/ to verify WASM binary sizes.
   - [x] CI Pipeline: Updated .github/workflows/ci.yml to automatically execute check_size.sh after the WASM build step.
   - [x] Configuration: Audited and confirmed Cargo.toml [profile.release] configuration (opt-level = "z", lto = true,
     codegen-units = 1).

  Verification
   - The check_size.sh script is configured with MAX_SIZE=46080 (45KB).
   - The CI build will now fail if any generated WASM binary in target/wasm32-unknown-unknown/release exceeds the defined
     threshold.

  Checklist
   - [x] Verified existing Cargo.toml optimization settings.
   - [x] Created check_size.sh for binary size validation.
   - [x] Integrated check_size.sh into ci.yml.
   - [x] Confirmed CI step fails on exceeding binary sizes.

  Closes #619 