### PR TITLE
ci: add automated WASM build workflow for release tags (closes #620)

### DIFF
--- a/.github/workflows/wasm.yml
+++ b/.github/workflows/wasm.yml
@@ -1,0 +1,86 @@
+name: WASM Release Build
+
+on:
+  push:
+    tags:
+      - "v*"
+
+permissions:
+  contents: write
+
+env:
+  CARGO_TERM_COLOR: always
+  WASM_TARGET: wasm32-unknown-unknown
+
+jobs:
+  build-wasm:
+    name: Build WASM & Upload Release Assets
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: ${{ env.WASM_TARGET }}
+
+      - name: Cache cargo registry
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-wasm-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: ${{ runner.os }}-cargo-wasm-
+
+      - name: Build WASM contracts
+        run: cargo build --target ${{ env.WASM_TARGET }} --release
+
+      - name: Collect WASM binaries
+        id: collect
+        run: |
+          mkdir -p artifacts
+          find target/${{ env.WASM_TARGET }}/release -maxdepth 1 -name "*.wasm" -exec cp {} artifacts/ \;
+
+          echo "Collected WASM binaries:"
+          ls -lh artifacts/
+
+          count=$(find artifacts -name "*.wasm" | wc -l)
+          if [ "$count" -eq 0 ]; then
+            echo "::error::No WASM binaries found after build"
+            exit 1
+          fi
+          echo "wasm_count=$count" >> "$GITHUB_OUTPUT"
+
+      - name: Generate SHA-256 checksums
+        run: |
+          cd artifacts
+          for file in *.wasm; do
+            sha256sum "$file" > "${file}.sha256"
+          done
+
+          echo "Checksums:"
+          cat *.sha256
+
+      - name: Verify WASM size limits
+        run: |
+          chmod +x check_size.sh
+          ./check_size.sh
+
+      - name: Upload release assets
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          tag="${GITHUB_REF_NAME}"
+          echo "Uploading assets for release: $tag"
+
+          cd artifacts
+          for file in *.wasm; do
+            gh release upload "$tag" "$file" --clobber
+            echo "  Uploaded: $file"
+          done
+          for file in *.sha256; do
+            gh release upload "$tag" "$file" --clobber
+            echo "  Uploaded: $file"
+          done


### PR DESCRIPTION
## Summary

Adds a GitHub Actions workflow that automatically compiles all workspace contracts to WASM binaries, generates SHA-256 checksums, and uploads both artifacts to the GitHub Release when a version tag is pushed.

Closes #620

---

## What This Workflow Does

When you push a tag like `v1.0.0`, the workflow automatically:

1. **Installs Rust** with the `wasm32-unknown-unknown` target (matching the existing CI)
2. **Builds all contracts** — the workspace contains 7 contracts with `cdylib` crate type: `analytics-engine`, `gas-tank`, `hello-world`, `liquidity-lock`, `price-oracle`, `reward-splitter`, and the root `stellarflow-contracts`
3. **Collects WASM binaries** from `target/wasm32-unknown-unknown/release/*.wasm`
4. **Generates SHA-256 checksums** — one `.sha256` file per WASM binary for integrity verification
5. **Verifies size limits** — runs the existing `check_size.sh` to enforce the 45KB WASM size cap
6. **Uploads to the Release** — uses `gh release upload` to attach all WASM binaries and checksum files

## Workflow Trigger

```yaml
on:
  push:
    tags:
      - "v*"
```

Fires on any tag starting with `v` (e.g., `v0.1.0`, `v1.0.0-beta.1`).

## Release Asset Example

After a successful run of `git tag v1.0.0 && git push origin v1.0.0`, the release will contain:

| Asset | Description |
|---|---|
| `analytics-engine.wasm` | Compiled WASM binary |
| `analytics-engine.wasm.sha256` | SHA-256 checksum |
| `gas-tank.wasm` | Compiled WASM binary |
| `gas-tank.wasm.sha256` | SHA-256 checksum |
| `hello-world.wasm` | Compiled WASM binary |
| `hello-world.wasm.sha256` | SHA-256 checksum |
| ... (all 7+ contracts) | |

## Technical Details

- **Target**: `wasm32-unknown-unknown` — consistent with the existing CI workflow (`ci.yml`)
- **Build mode**: `--release` with the project's optimized profile (`opt-level = "z"`, LTO, single codegen unit, strip symbols)
- **Caching**: Uses `actions/cache@v4` for cargo registry and build artifacts, keyed on `Cargo.lock`
- **Checksums**: Standard `sha256sum` format (`<hash>  <filename>`), suitable for `sha256sum -c` verification
- **Permissions**: `contents: write` — required for `gh release upload`
- **Idempotent**: Uses `--clobber` flag so re-runs overwrite existing assets without failure

## Verification

- YAML syntax validated
- Workflow structure follows the existing `ci.yml` patterns (same Rust toolchain action, same cache strategy)
- `check_size.sh` integration ensures WASM binaries stay under the 45KB limit before upload
- Early exit if no WASM binaries are produced (prevents uploading empty release)
