### PR TITLE
feat: maximum slippage tolerance enforcement

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1252,6 +1252,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "stellarflow-benchmarks"
+version = "0.0.0"
+dependencies = [
+ "price-oracle",
+ "soroban-sdk",
+]
+
+[[package]]
 name = "stellarflow-contracts"
 version = "0.1.0"
 dependencies = [

--- a/src/amm/mod.rs
+++ b/src/amm/mod.rs
@@ -1,0 +1,1 @@
+pub mod slippage;

--- a/src/amm/slippage.rs
+++ b/src/amm/slippage.rs
@@ -1,0 +1,74 @@
+use crate::ContractError;
+
+/// Enforce maximum slippage tolerance on a swap output.
+///
+/// Compares the final calculated output amount (`amount_out`) against the
+/// caller-specified minimum (`min_amount_out`). If the output falls below the
+/// threshold the transaction is aborted with
+/// [`ContractError::SlippageExceeded`], which reverts all state changes and
+/// protects the user from sandwich attacks and adverse price movement.
+///
+/// # Arguments
+/// * `amount_out` - The final output amount after fee deduction and pool math.
+/// * `min_amount_out` - The caller's hard minimum acceptable payout.
+///
+/// # Returns
+/// `Ok(amount_out)` if the check passes, allowing callers to chain the
+/// validated value directly.
+///
+/// # Errors
+/// * [`ContractError::SlippageExceeded`] — when `amount_out < min_amount_out`.
+pub fn enforce_slippage(
+    amount_out: u128,
+    min_amount_out: u128,
+) -> Result<u128, ContractError> {
+    if amount_out < min_amount_out {
+        return Err(ContractError::SlippageExceeded);
+    }
+    Ok(amount_out)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn passes_when_output_meets_minimum() {
+        assert_eq!(enforce_slippage(100, 100), Ok(100));
+    }
+
+    #[test]
+    fn passes_when_output_exceeds_minimum() {
+        assert_eq!(enforce_slippage(200, 100), Ok(200));
+    }
+
+    #[test]
+    fn fails_when_output_below_minimum() {
+        assert_eq!(enforce_slippage(99, 100), Err(ContractError::SlippageExceeded));
+    }
+
+    #[test]
+    fn fails_on_zero_output_with_nonzero_minimum() {
+        assert_eq!(enforce_slippage(0, 1), Err(ContractError::SlippageExceeded));
+    }
+
+    #[test]
+    fn passes_when_both_are_zero() {
+        assert_eq!(enforce_slippage(0, 0), Ok(0));
+    }
+
+    #[test]
+    fn large_values_enforced() {
+        let large_out = u128::MAX;
+        let large_min = u128::MAX;
+        assert_eq!(enforce_slippage(large_out, large_min), Ok(large_out));
+    }
+
+    #[test]
+    fn large_values_fail_when_below() {
+        assert_eq!(
+            enforce_slippage(u128::MAX - 1, u128::MAX),
+            Err(ContractError::SlippageExceeded)
+        );
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -44,6 +44,7 @@ pub fn asset_id_to_symbol(asset_id: u32) -> Symbol {
 pub(crate) mod nonce;
 use crate::nonce::{consume_nonce, get_nonce};
 
+pub mod amm;
 pub mod admin;
 pub mod auth;
 pub mod config;
@@ -154,6 +155,8 @@ pub enum ContractError {
     AdminChangeTimelockNotSatisfied = 45,
     /// The validator has no locked bond available to deduct an escrow penalty from.
     InsufficientBondForPenalty = 46,
+    /// The final swap output is below the caller's minimum acceptable amount.
+    SlippageExceeded = 47,
 }
 
 // Contract state keys


### PR DESCRIPTION
## Slippage-Protection | Maximum Slippage Tolerance Enforcement

Protect users from sandwich attacks and market volatility by enforcing minimum payout thresholds on swap outputs.

### Changes

**New files:**
- `src/amm/mod.rs` — Module declaration for the AMM subsystem
- `src/amm/slippage.rs` — Core slippage enforcement logic with `enforce_slippage(amount_out, min_amount_out)` function

**Modified files:**
- `src/lib.rs` — Added `pub mod amm;` and `ContractError::SlippageExceeded = 47` error variant

### Details

The `enforce_slippage` function validates the final calculated output against the caller's `min_amount_out` parameter. If `amount_out < min_amount_out`, the transaction aborts with `ContractError::SlippageExceeded`, reverting all state changes and preventing the user from receiving less than their specified minimum.

Includes seven unit tests covering pass/fail conditions, boundary cases, zero values, and large values.


Closes #601 