### PR TITLE
feat: implement stop-loss execution trigger contract handler (#730)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1407,6 +1407,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "stop-loss-trigger"
+version = "0.0.0"
+dependencies = [
+ "soroban-sdk",
+]
+
+[[package]]
 name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ members = [
     "contracts/price-oracle",
     "contracts/reward-splitter",
     "contracts/gas-tank",
+    "contracts/stop-loss-trigger",
     "tests/benchmarks",
     "tests/fuzz",
 ]

--- a/contracts/stop-loss-trigger/Cargo.toml
+++ b/contracts/stop-loss-trigger/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "stop-loss-trigger"
+version = "0.0.0"
+edition = "2021"
+publish = false
+
+[lib]
+crate-type = ["cdylib", "rlib"]
+doctest = false
+
+[dependencies]
+soroban-sdk = { version = "=20.0.0", default-features = false }
+
+[dev-dependencies]
+soroban-sdk = { version = "=20.0.0", default-features = false, features = ["testutils"] }

--- a/contracts/stop-loss-trigger/src/lib.rs
+++ b/contracts/stop-loss-trigger/src/lib.rs
@@ -1,0 +1,497 @@
+//! Stop-Loss Execution Trigger Contract Handler (Issue #730).
+//!
+//! A conditional execution wrapper that swaps user positions when the
+//! verified TWAP oracle price crosses a target threshold.
+//!
+//! # Flow
+//!
+//! 1. **Register** — a user posts a trigger: they escrow `sell_amount` of
+//!    `sell_asset`, pick a `stop_price`, a trigger direction
+//!    ([`TriggerCondition::PriceBelow`] for stop-loss protection, or
+//!    [`TriggerCondition::PriceAbove`] for the mirror case), and configure
+//!    slippage bounds (`min_fill_price`, `max_fill_price`, `min_amount_out`).
+//! 2. **Execute** — any keeper may submit an execution for a trigger. The
+//!    handler *never* trusts keeper-supplied data: it re-reads the
+//!    time-weighted average price straight from the registered price-oracle
+//!    contract (`get_twap`) and rejects the keeper submission when the
+//!    claimed price does not match the verified TWAP.
+//! 3. **Swap** — when the verified TWAP breaches the stop price the handler
+//!    atomically executes the market swap: the escrowed `sell_asset` is
+//!    absorbed by the pool and `buy_asset` is paid to the owner at the
+//!    oracle-verified fill price. If the resulting fill price (or proceeds)
+//!    fall outside the slippage bounds configured by the user the whole
+//!    execution reverts with [`ContractError::SlippageExceeded`].
+//! 4. **Cancel** — the owner may cancel an unfired trigger at any time and
+//!    recover the escrowed balance.
+//!
+//! # Security model
+//!
+//! * **Oracle-verified pricing** — the trigger condition and the fill price
+//!   are derived exclusively from the oracle contract's `get_twap` view,
+//!   which averages the last ten verified price updates. Keepers
+//!   cannot fabricate a price: `claimed_twap` must equal the on-chain TWAP
+//!   or the submission is rejected with
+//!   [`ContractError::TriggerPriceNotVerified`]. In production the oracle
+//!   address is the `price-oracle` contract shipped with this workspace; the
+//!   handler only relies on the `get_twap(Symbol) -> Option<i128>` interface,
+//!   so any verified TWAP feed with the same surface can be registered.
+//! * **User-configured slippage bounds** — if the fill price leaves the
+//!   `[min_fill_price, max_fill_price]` corridor, or the proceeds fall below
+//!   `min_amount_out`, execution reverts. Soroban's transaction atomicity
+//!   guarantees no partial state or balance movement survives the revert.
+//! * **Escrow custody** — funds stay locked in the handler until the trigger
+//!   fires or the owner cancels; keepers only get to *trigger* execution,
+//!   never to touch the escrow themselves.
+//! * **Checked arithmetic** — all price math uses `checked_*` operations so
+//!   overflow can never silently mis-price a fill.
+//! * **Permissionless, attributable execution** — keepers authenticate via
+//!   `require_auth` so every execution is attributable on-chain, but no
+//!   keeper allowlist is required (bots are expected to call this).
+
+#![no_std]
+
+use soroban_sdk::{
+    contract, contracterror, contractimpl, contracttype, symbol_short, token, Address, Env,
+    IntoVal, Symbol,
+};
+
+/// Fixed-point scale for all prices (`stop_price`, fill prices and the oracle
+/// TWAP), in units of `buy_asset` per 1 whole unit of `sell_asset`.
+/// Matches the fixed-point footprint used by the protocol elsewhere.
+pub const PRICE_SCALE: i128 = 10_000_000;
+
+/// Persistent-storage TTL floor / extension target (in ledgers) applied to
+/// trigger records so unfired triggers survive rent collection.
+const TTL_THRESHOLD: u32 = 120_960;
+const TTL_EXTEND_TO: u32 = 535_680;
+
+#[contracterror]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
+#[repr(u32)]
+pub enum ContractError {
+    AlreadyInitialized = 1,
+    NotInitialized = 2,
+    NotAdmin = 3,
+    TriggerNotFound = 4,
+    TriggerNotActive = 5,
+    NotTriggerOwner = 6,
+    InvalidAmount = 7,
+    InvalidTriggerPrice = 8,
+    InvalidSlippageBounds = 9,
+    /// The TWAP oracle returned no verified price for the trigger's feed.
+    OraclePriceUnavailable = 10,
+    /// The keeper's submitted price does not match the verified TWAP oracle price.
+    TriggerPriceNotVerified = 11,
+    /// The verified TWAP has not (yet) crossed the configured stop price.
+    TriggerConditionNotMet = 12,
+    /// The resulting fill price / proceeds exceed the user-configured slippage bounds.
+    SlippageExceeded = 13,
+    /// The pool does not hold enough `buy_asset` to settle the swap.
+    InsufficientLiquidity = 14,
+    MathOverflow = 15,
+}
+
+/// Direction in which the verified TWAP must cross `stop_price` for the
+/// trigger to fire.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum TriggerCondition {
+    /// Stop-loss: fire when the TWAP drops to (or below) `stop_price`.
+    PriceBelow,
+    /// Mirror direction: fire when the TWAP rises to (or above) `stop_price`.
+    PriceAbove,
+}
+
+/// A user-posted conditional swap order held by the handler.
+#[contracttype]
+#[derive(Clone, Debug, PartialEq)]
+pub struct StopLossTrigger {
+    pub id: u64,
+    pub owner: Address,
+    /// Asset the owner escrows and sells when the trigger fires.
+    pub sell_asset: Address,
+    /// Asset the owner receives from the pool when the trigger fires.
+    pub buy_asset: Address,
+    /// TWAP oracle feed symbol used for price validation.
+    pub oracle_symbol: Symbol,
+    pub sell_amount: i128,
+    /// Price threshold at/through which the trigger fires (fixed-point).
+    pub stop_price: i128,
+    pub condition: TriggerCondition,
+    /// Slippage bound: minimum acceptable fill price (fixed-point).
+    pub min_fill_price: i128,
+    /// Slippage bound: maximum acceptable fill price (fixed-point).
+    pub max_fill_price: i128,
+    /// Slippage bound: minimum acceptable proceeds of `buy_asset`.
+    pub min_amount_out: i128,
+    pub created_at: u64,
+    pub active: bool,
+}
+
+/// Result of a successful trigger execution.
+#[contracttype]
+#[derive(Clone, Debug, PartialEq)]
+pub struct ExecutionResult {
+    pub trigger_id: u64,
+    pub executed_at: u64,
+    /// The verified TWAP read from the oracle at execution time.
+    pub twap_price: i128,
+    /// Effective fill price (fixed-point) the swap settled at.
+    pub fill_price: i128,
+    /// Amount of `buy_asset` paid to the owner.
+    pub proceeds: i128,
+}
+
+/// Contract-level configuration.
+#[contracttype]
+#[derive(Clone, Debug, PartialEq)]
+pub struct Config {
+    pub admin: Address,
+    /// Address of the price-oracle contract used for TWAP validation.
+    pub oracle: Address,
+}
+
+#[contracttype]
+pub enum DataKey {
+    Config,
+    NextTriggerId,
+    Trigger(u64),
+}
+
+#[contract]
+pub struct StopLossTriggerContract;
+
+#[contractimpl]
+impl StopLossTriggerContract {
+    /// Initialize the handler with the admin and the price-oracle contract
+    /// whose verified TWAP feeds all trigger validations.
+    pub fn initialize(env: Env, admin: Address, oracle: Address) -> Result<(), ContractError> {
+        admin.require_auth();
+        if env.storage().instance().has(&DataKey::Config) {
+            return Err(ContractError::AlreadyInitialized);
+        }
+        env.storage()
+            .instance()
+            .set(&DataKey::Config, &Config { admin, oracle });
+        Ok(())
+    }
+
+    /// Admin-only: point the handler at a different oracle contract.
+    pub fn set_oracle(env: Env, admin: Address, oracle: Address) -> Result<(), ContractError> {
+        admin.require_auth();
+        let mut config = Self::config(&env)?;
+        if config.admin != admin {
+            return Err(ContractError::NotAdmin);
+        }
+        config.oracle = oracle;
+        env.storage().instance().set(&DataKey::Config, &config);
+        Ok(())
+    }
+
+    /// Return the current handler configuration, if initialized.
+    pub fn get_config(env: Env) -> Option<Config> {
+        env.storage().instance().get(&DataKey::Config)
+    }
+
+    /// Register a stop-loss (or mirror) trigger and escrow the sold asset.
+    ///
+    /// # Errors
+    /// - [`ContractError::InvalidAmount`] when `sell_amount <= 0`.
+    /// - [`ContractError::InvalidTriggerPrice`] when `stop_price <= 0`.
+    /// - [`ContractError::InvalidSlippageBounds`] when the slippage
+    ///   configuration is inconsistent (`min_fill_price <= 0`,
+    ///   `max_fill_price < min_fill_price`, or `min_amount_out < 0`).
+    pub fn register_trigger(
+        env: Env,
+        owner: Address,
+        sell_asset: Address,
+        buy_asset: Address,
+        oracle_symbol: Symbol,
+        sell_amount: i128,
+        stop_price: i128,
+        condition: TriggerCondition,
+        min_fill_price: i128,
+        max_fill_price: i128,
+        min_amount_out: i128,
+    ) -> Result<StopLossTrigger, ContractError> {
+        owner.require_auth();
+        Self::validate_trigger_params(
+            sell_amount,
+            stop_price,
+            min_fill_price,
+            max_fill_price,
+            min_amount_out,
+        )?;
+
+        let sell_client = token::Client::new(&env, &sell_asset);
+        sell_client.transfer(&owner, &env.current_contract_address(), &sell_amount);
+
+        let id = Self::next_trigger_id(&env);
+        let trigger = StopLossTrigger {
+            id,
+            owner,
+            sell_asset,
+            buy_asset,
+            oracle_symbol,
+            sell_amount,
+            stop_price,
+            condition,
+            min_fill_price,
+            max_fill_price,
+            min_amount_out,
+            created_at: env.ledger().timestamp(),
+            active: true,
+        };
+        let key = DataKey::Trigger(id);
+        env.storage().persistent().set(&key, &trigger);
+        env.storage()
+            .persistent()
+            .extend_ttl(&key, TTL_THRESHOLD, TTL_EXTEND_TO);
+
+        env.events().publish(
+            (symbol_short!("trig_reg"), id),
+            (trigger.owner.clone(), trigger.sell_amount),
+        );
+
+        Ok(trigger)
+    }
+
+    /// Keeper entrypoint: validate the trigger submission against the
+    /// verified TWAP oracle price and, when the stop condition is breached,
+    /// automatically execute the market swap in the same atomic call.
+    ///
+    /// # Errors
+    /// - [`ContractError::TriggerNotFound`] for unknown trigger ids.
+    /// - [`ContractError::TriggerNotActive`] for cancelled / already-executed
+    ///   triggers.
+    /// - [`ContractError::OraclePriceUnavailable`] when the oracle has no
+    ///   verified TWAP for the trigger's feed.
+    /// - [`ContractError::TriggerPriceNotVerified`] when the keeper's
+    ///   `claimed_twap` does not match the verified TWAP oracle price.
+    /// - [`ContractError::TriggerConditionNotMet`] when the verified TWAP
+    ///   has not crossed `stop_price`.
+    /// - [`ContractError::SlippageExceeded`] when the resulting fill price
+    ///   (or proceeds) breach the user-configured slippage bounds — the
+    ///   whole execution reverts.
+    /// - [`ContractError::InsufficientLiquidity`] when the pool cannot
+    ///   settle the swap.
+    pub fn execute_trigger(
+        env: Env,
+        keeper: Address,
+        trigger_id: u64,
+        claimed_twap: i128,
+    ) -> Result<ExecutionResult, ContractError> {
+        keeper.require_auth();
+
+        let config = Self::config(&env)?;
+        let key = DataKey::Trigger(trigger_id);
+        let trigger: StopLossTrigger = env
+            .storage()
+            .persistent()
+            .get(&key)
+            .ok_or(ContractError::TriggerNotFound)?;
+        if !trigger.active {
+            return Err(ContractError::TriggerNotActive);
+        }
+
+        // 1. Read the verified TWAP straight from the price oracle. Keeper
+        //    input is never trusted as the source of truth.
+        let twap = Self::read_verified_twap(&env, &config.oracle, &trigger.oracle_symbol)?;
+
+        // 2. Validate the keeper's trigger submission against the verified
+        //    TWAP oracle price. A keeper quoting anything else is rejected
+        //    before any state is touched.
+        if claimed_twap != twap {
+            return Err(ContractError::TriggerPriceNotVerified);
+        }
+
+        // 3. Stop condition breach check.
+        let breached = match trigger.condition {
+            TriggerCondition::PriceBelow => twap <= trigger.stop_price,
+            TriggerCondition::PriceAbove => twap >= trigger.stop_price,
+        };
+        if !breached {
+            return Err(ContractError::TriggerConditionNotMet);
+        }
+
+        // 4. Slippage bounds: revert the execution when the resulting fill
+        //    price leaves the corridor configured by the user.
+        if twap < trigger.min_fill_price || twap > trigger.max_fill_price {
+            return Err(ContractError::SlippageExceeded);
+        }
+
+        // 5. Derive proceeds at the oracle-verified fill price.
+        let proceeds = trigger
+            .sell_amount
+            .checked_mul(twap)
+            .ok_or(ContractError::MathOverflow)?
+            .checked_div(PRICE_SCALE)
+            .ok_or(ContractError::MathOverflow)?;
+
+        if proceeds < trigger.min_amount_out {
+            return Err(ContractError::SlippageExceeded);
+        }
+
+        // 6. Execute the market swap: pay `buy_asset` out of the pool and
+        //    retain the sold asset in the pool. Soroban atomicity reverts
+        //    every write here if any subsequent step fails.
+        let buy_client = token::Client::new(&env, &trigger.buy_asset);
+        if buy_client.balance(&env.current_contract_address()) < proceeds {
+            return Err(ContractError::InsufficientLiquidity);
+        }
+        buy_client.transfer(&env.current_contract_address(), &trigger.owner, &proceeds);
+
+        let mut executed = trigger.clone();
+        executed.active = false;
+        env.storage().persistent().set(&key, &executed);
+
+        env.events().publish(
+            (symbol_short!("trig_exec"), trigger_id),
+            (trigger.owner, twap, proceeds),
+        );
+
+        Ok(ExecutionResult {
+            trigger_id,
+            executed_at: env.ledger().timestamp(),
+            twap_price: twap,
+            fill_price: twap,
+            proceeds,
+        })
+    }
+
+    /// Cancel a still-active trigger and refund the escrowed `sell_asset`.
+    ///
+    /// Only the trigger owner may cancel. Keepers cannot cancel orders.
+    pub fn cancel_trigger(
+        env: Env,
+        owner: Address,
+        trigger_id: u64,
+    ) -> Result<i128, ContractError> {
+        owner.require_auth();
+
+        let key = DataKey::Trigger(trigger_id);
+        let mut trigger: StopLossTrigger = env
+            .storage()
+            .persistent()
+            .get(&key)
+            .ok_or(ContractError::TriggerNotFound)?;
+        if trigger.owner != owner {
+            return Err(ContractError::NotTriggerOwner);
+        }
+        if !trigger.active {
+            return Err(ContractError::TriggerNotActive);
+        }
+
+        let refund = trigger.sell_amount;
+        trigger.active = false;
+        env.storage().persistent().set(&key, &trigger);
+
+        if refund > 0 {
+            let sell_client = token::Client::new(&env, &trigger.sell_asset);
+            sell_client.transfer(&env.current_contract_address(), &owner, &refund);
+        }
+
+        env.events()
+            .publish((symbol_short!("trig_cxl"), trigger_id), (owner, refund));
+
+        Ok(refund)
+    }
+
+    /// Query a trigger by id.
+    pub fn get_trigger(env: Env, trigger_id: u64) -> Option<StopLossTrigger> {
+        env.storage()
+            .persistent()
+            .get(&DataKey::Trigger(trigger_id))
+    }
+
+    /// Permissionless liquidity provision: deposit `asset` into the handler's
+    /// pool so stop-loss executions can be settled.
+    pub fn fund_pool(
+        env: Env,
+        funder: Address,
+        asset: Address,
+        amount: i128,
+    ) -> Result<i128, ContractError> {
+        funder.require_auth();
+        if amount <= 0 {
+            return Err(ContractError::InvalidAmount);
+        }
+        token::Client::new(&env, &asset).transfer(
+            &funder,
+            &env.current_contract_address(),
+            &amount,
+        );
+        Ok(amount)
+    }
+
+    /// Query the handler pool's balance of `asset`.
+    pub fn get_pool_balance(env: Env, asset: Address) -> i128 {
+        token::Client::new(&env, &asset).balance(&env.current_contract_address())
+    }
+
+    // ── Private helpers ──────────────────────────────────────────────────────
+
+    fn config(env: &Env) -> Result<Config, ContractError> {
+        env.storage()
+            .instance()
+            .get(&DataKey::Config)
+            .ok_or(ContractError::NotInitialized)
+    }
+
+    /// Cross-contract read of the verified TWAP from the registered oracle.
+    ///
+    /// The oracle contract must expose the `get_twap(Symbol) ->
+    /// Result<Option<i128>, contracterror>` interface (as `price-oracle` in
+    /// this workspace does). Any oracle error — or a missing TWAP buffer —
+    /// is surfaced as [`ContractError::OraclePriceUnavailable`] so execution
+    /// reverts cleanly instead of mis-pricing a fill.
+    fn read_verified_twap(
+        env: &Env,
+        oracle: &Address,
+        oracle_symbol: &Symbol,
+    ) -> Result<i128, ContractError> {
+        let result: Result<Option<i128>, soroban_sdk::Error> = env.invoke_contract(
+            oracle,
+            &symbol_short!("get_twap"),
+            soroban_sdk::vec![env, oracle_symbol.into_val(env)],
+        );
+        match result {
+            Ok(Some(twap)) => Ok(twap),
+            _ => Err(ContractError::OraclePriceUnavailable),
+        }
+    }
+
+    fn next_trigger_id(env: &Env) -> u64 {
+        let id: u64 = env
+            .storage()
+            .instance()
+            .get(&DataKey::NextTriggerId)
+            .unwrap_or(0);
+        env.storage()
+            .instance()
+            .set(&DataKey::NextTriggerId, &(id + 1));
+        id
+    }
+
+    fn validate_trigger_params(
+        sell_amount: i128,
+        stop_price: i128,
+        min_fill_price: i128,
+        max_fill_price: i128,
+        min_amount_out: i128,
+    ) -> Result<(), ContractError> {
+        if sell_amount <= 0 {
+            return Err(ContractError::InvalidAmount);
+        }
+        if stop_price <= 0 {
+            return Err(ContractError::InvalidTriggerPrice);
+        }
+        if min_fill_price <= 0 || max_fill_price < min_fill_price || min_amount_out < 0 {
+            return Err(ContractError::InvalidSlippageBounds);
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod test;

--- a/contracts/stop-loss-trigger/src/test.rs
+++ b/contracts/stop-loss-trigger/src/test.rs
@@ -1,0 +1,801 @@
+#![cfg(test)]
+
+use super::*;
+use soroban_sdk::{
+    contract, contracterror, contractimpl, contracttype, symbol_short,
+    testutils::{Address as _, Events},
+    token::{Client as TokenClient, StellarAssetClient},
+    Address, Env, Symbol, TryFromVal, Vec,
+};
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Mock TWAP oracle
+// ─────────────────────────────────────────────────────────────────────────────
+//
+// Minimal, faithful stand-in for the workspace `price-oracle` contract used by
+// the tests: it exposes the exact same `get_twap` cross-contract interface the
+// handler calls (last-10 verified price updates averaged, `None` when the
+// buffer is empty, `Err` when halted).
+
+#[contracttype]
+#[derive(Clone, Debug, PartialEq)]
+enum MockDataKey {
+    TwapBuffer(Symbol),
+}
+
+#[contracterror]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
+#[repr(u32)]
+enum MockOracleError {
+    EmergencyHalted = 1,
+}
+
+#[contract]
+struct MockTwapOracle;
+
+#[contractimpl]
+impl MockTwapOracle {
+    pub fn set_price(env: Env, asset: Symbol, price: i128) -> Result<(), MockOracleError> {
+        let key = MockDataKey::TwapBuffer(asset);
+        let mut buffer: Vec<(u64, i128)> = env
+            .storage()
+            .temporary()
+            .get(&key)
+            .unwrap_or_else(|| Vec::new(&env));
+        buffer.push_back((env.ledger().timestamp(), price));
+        if buffer.len() > 10 {
+            buffer.pop_front();
+        }
+        env.storage().temporary().set(&key, &buffer);
+        Ok(())
+    }
+
+    pub fn get_twap(env: Env, asset: Symbol) -> Result<Option<i128>, MockOracleError> {
+        let key = MockDataKey::TwapBuffer(asset);
+        let buffer: Option<Vec<(u64, i128)>> = env.storage().temporary().get(&key);
+        match buffer {
+            None => Ok(None),
+            Some(buf) if buf.len() == 0 => Ok(None),
+            Some(buf) => {
+                let mut sum: i128 = 0;
+                for (_, price) in buf.iter() {
+                    sum += price;
+                }
+                Ok(Some(sum / buf.len() as i128))
+            }
+        }
+    }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Test helpers
+// ─────────────────────────────────────────────────────────────────────────────
+
+fn setup() -> (
+    Env,
+    StopLossTriggerContractClient<'static>,
+    MockTwapOracleClient<'static>,
+    Address,
+) {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    // Register the mock TWAP oracle (stand-in for the price-oracle contract).
+    let oracle_id = env.register_contract(None, MockTwapOracle);
+    let oracle_client = MockTwapOracleClient::new(&env, &oracle_id);
+
+    // Register and initialize the stop-loss trigger handler.
+    let admin = Address::generate(&env);
+    let handler_id = env.register_contract(None, StopLossTriggerContract);
+    let client = StopLossTriggerContractClient::new(&env, &handler_id);
+    client.initialize(&admin, &oracle_id);
+
+    (env, client, oracle_client, admin)
+}
+
+/// Push `prices` into the mock oracle's verified TWAP buffer.
+fn seed_twap(oracle_client: &MockTwapOracleClient, symbol: &Symbol, prices: &[i128]) {
+    for price in prices.iter() {
+        oracle_client.set_price(symbol, &price);
+    }
+}
+
+fn mint(env: &Env, asset: &Address, to: &Address, amount: i128) {
+    StellarAssetClient::new(env, asset).mint(to, &amount);
+}
+
+fn balance(env: &Env, asset: &Address, holder: &Address) -> i128 {
+    TokenClient::new(env, asset).balance(holder)
+}
+
+/// True when any event emitted so far carries `topic` as its first topic.
+fn event_has_topic(env: &Env, topic: &Symbol) -> bool {
+    env.events().all().iter().any(|(_, topics, _)| {
+        if topics.len() == 0 {
+            return false;
+        }
+        match Symbol::try_from_val(env, &topics.get(0).unwrap()) {
+            Ok(s) => s == *topic,
+            Err(_) => false,
+        }
+    })
+}
+
+/// Create the sell/buy tokens and a standard stop-loss trigger:
+/// sell 1_000 SELL, stop at 1.20e9, TWAP seeded at 1.00e9 (breached),
+/// slippage corridor [9.0e8, 1.10e9], min proceeds 90_000.
+fn register_standard_trigger(
+    client: &StopLossTriggerContractClient,
+    owner: &Address,
+    sell_asset: &Address,
+    buy_asset: &Address,
+) -> StopLossTrigger {
+    client.register_trigger(
+        owner,
+        sell_asset,
+        buy_asset,
+        &symbol_short!("NGN"),
+        &1_000i128,
+        &1_200_000_000i128,
+        &TriggerCondition::PriceBelow,
+        &900_000_000i128,
+        &1_100_000_000i128,
+        &90_000i128,
+    )
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Tests
+// ─────────────────────────────────────────────────────────────────────────────
+
+#[test]
+fn initialize_sets_config_and_rejects_double_init() {
+    let (env, client, _, admin) = setup();
+    let config = client.get_config().unwrap();
+    assert_eq!(config.admin, admin);
+
+    let second = Address::generate(&env);
+    let other_oracle = Address::generate(&env);
+    let result = client.try_initialize(&second, &other_oracle);
+    assert_eq!(result, Err(Ok(ContractError::AlreadyInitialized)));
+}
+
+#[test]
+fn set_oracle_requires_current_admin() {
+    let (env, client, _, _) = setup();
+    let new_oracle = Address::generate(&env);
+
+    let intruder = Address::generate(&env);
+    let result = client.try_set_oracle(&intruder, &new_oracle);
+    assert_eq!(result, Err(Ok(ContractError::NotAdmin)));
+}
+
+#[test]
+fn register_trigger_escrows_sell_asset() {
+    let (env, client, _, _) = setup();
+    let owner = Address::generate(&env);
+    let sell_issuer = Address::generate(&env);
+    let buy_issuer = Address::generate(&env);
+    let sell_asset = env.register_stellar_asset_contract(sell_issuer);
+    let buy_asset = env.register_stellar_asset_contract(buy_issuer);
+    mint(&env, &sell_asset, &owner, 1_000);
+
+    let trigger = register_standard_trigger(&client, &owner, &sell_asset, &buy_asset);
+
+    assert_eq!(trigger.owner, owner);
+    assert_eq!(trigger.sell_amount, 1_000);
+    assert!(trigger.active);
+    assert_eq!(balance(&env, &sell_asset, &owner), 0);
+    assert_eq!(client.get_pool_balance(&sell_asset), 1_000);
+
+    let stored = client.get_trigger(&trigger.id).unwrap();
+    assert_eq!(stored, trigger);
+}
+
+#[test]
+fn register_rejects_invalid_params() {
+    let (env, client, _, _) = setup();
+    let owner = Address::generate(&env);
+    let sell_issuer = Address::generate(&env);
+    let buy_issuer = Address::generate(&env);
+    let sell_asset = env.register_stellar_asset_contract(sell_issuer);
+    let buy_asset = env.register_stellar_asset_contract(buy_issuer);
+    mint(&env, &sell_asset, &owner, 1_000);
+
+    let zero_amount = client.try_register_trigger(
+        &owner,
+        &sell_asset,
+        &buy_asset,
+        &symbol_short!("NGN"),
+        &0i128,
+        &1_200_000_000i128,
+        &TriggerCondition::PriceBelow,
+        &900_000_000i128,
+        &1_100_000_000i128,
+        &0i128,
+    );
+    assert_eq!(zero_amount, Err(Ok(ContractError::InvalidAmount)));
+
+    let zero_stop = client.try_register_trigger(
+        &owner,
+        &sell_asset,
+        &buy_asset,
+        &symbol_short!("NGN"),
+        &1_000i128,
+        &0i128,
+        &TriggerCondition::PriceBelow,
+        &900_000_000i128,
+        &1_100_000_000i128,
+        &0i128,
+    );
+    assert_eq!(zero_stop, Err(Ok(ContractError::InvalidTriggerPrice)));
+
+    let inverted_bounds = client.try_register_trigger(
+        &owner,
+        &sell_asset,
+        &buy_asset,
+        &symbol_short!("NGN"),
+        &1_000i128,
+        &1_200_000_000i128,
+        &TriggerCondition::PriceBelow,
+        &1_100_000_000i128,
+        &900_000_000i128,
+        &0i128,
+    );
+    assert_eq!(
+        inverted_bounds,
+        Err(Ok(ContractError::InvalidSlippageBounds))
+    );
+
+    let negative_min_out = client.try_register_trigger(
+        &owner,
+        &sell_asset,
+        &buy_asset,
+        &symbol_short!("NGN"),
+        &1_000i128,
+        &1_200_000_000i128,
+        &TriggerCondition::PriceBelow,
+        &900_000_000i128,
+        &1_100_000_000i128,
+        &-1i128,
+    );
+    assert_eq!(
+        negative_min_out,
+        Err(Ok(ContractError::InvalidSlippageBounds))
+    );
+}
+
+#[test]
+fn execute_on_stop_loss_breach_swaps_position() {
+    let (env, client, oracle_client, _) = setup();
+    let handler = client.address.clone();
+    let owner = Address::generate(&env);
+    let keeper = Address::generate(&env);
+    let sell_issuer = Address::generate(&env);
+    let buy_issuer = Address::generate(&env);
+    let sell_asset = env.register_stellar_asset_contract(sell_issuer);
+    let buy_asset = env.register_stellar_asset_contract(buy_issuer);
+    mint(&env, &sell_asset, &owner, 1_000);
+    mint(&env, &buy_asset, &handler, 500_000);
+
+    // Verified TWAP = 1.00e9 — below the 1.20e9 stop → breach.
+    seed_twap(
+        &oracle_client,
+        &symbol_short!("NGN"),
+        &[1_000_000_000, 1_000_000_000, 1_000_000_000],
+    );
+
+    let trigger = register_standard_trigger(&client, &owner, &sell_asset, &buy_asset);
+
+    let result = client.execute_trigger(&keeper, &trigger.id, &1_000_000_000i128);
+
+    assert_eq!(result.twap_price, 1_000_000_000);
+    assert_eq!(result.fill_price, 1_000_000_000);
+    // proceeds = 1_000 * 1.00e9 / 1e7 = 100_000
+    assert_eq!(result.proceeds, 100_000);
+
+    // Position swapped: owner now holds buy_asset, pool absorbed sell_asset.
+    assert_eq!(balance(&env, &buy_asset, &owner), 100_000);
+    assert_eq!(balance(&env, &sell_asset, &handler), 1_000);
+    assert!(!client.get_trigger(&trigger.id).unwrap().active);
+}
+
+#[test]
+fn execute_fires_at_exact_stop_price_boundary() {
+    let (env, client, oracle_client, _) = setup();
+    let handler = client.address.clone();
+    let owner = Address::generate(&env);
+    let keeper = Address::generate(&env);
+    let sell_issuer = Address::generate(&env);
+    let buy_issuer = Address::generate(&env);
+    let sell_asset = env.register_stellar_asset_contract(sell_issuer);
+    let buy_asset = env.register_stellar_asset_contract(buy_issuer);
+    mint(&env, &sell_asset, &owner, 1_000);
+    mint(&env, &buy_asset, &handler, 500_000);
+
+    // TWAP exactly equals the stop price → inclusive breach.
+    seed_twap(
+        &oracle_client,
+        &symbol_short!("NGN"),
+        &[1_200_000_000, 1_200_000_000, 1_200_000_000],
+    );
+
+    // Slippage corridor [1.00e9, 1.20e9] accepts the 1.20e9 fill so the
+    // boundary condition itself is what is exercised.
+    let trigger = client.register_trigger(
+        &owner,
+        &sell_asset,
+        &buy_asset,
+        &symbol_short!("NGN"),
+        &1_000i128,
+        &1_200_000_000i128,
+        &TriggerCondition::PriceBelow,
+        &1_000_000_000i128,
+        &1_200_000_000i128,
+        &100_000i128,
+    );
+
+    let result = client.execute_trigger(&keeper, &trigger.id, &1_200_000_000i128);
+    assert_eq!(result.proceeds, 120_000);
+    assert!(!client.get_trigger(&trigger.id).unwrap().active);
+}
+
+#[test]
+fn execute_price_above_direction_fires_on_rise() {
+    let (env, client, oracle_client, _) = setup();
+    let handler = client.address.clone();
+    let owner = Address::generate(&env);
+    let keeper = Address::generate(&env);
+    let sell_issuer = Address::generate(&env);
+    let buy_issuer = Address::generate(&env);
+    let sell_asset = env.register_stellar_asset_contract(sell_issuer);
+    let buy_asset = env.register_stellar_asset_contract(buy_issuer);
+    mint(&env, &sell_asset, &owner, 1_000);
+    mint(&env, &buy_asset, &handler, 500_000);
+
+    seed_twap(
+        &oracle_client,
+        &symbol_short!("NGN"),
+        &[1_200_000_000, 1_200_000_000, 1_200_000_000],
+    );
+
+    let trigger = client.register_trigger(
+        &owner,
+        &sell_asset,
+        &buy_asset,
+        &symbol_short!("NGN"),
+        &1_000i128,
+        &1_000_000_000i128,
+        &TriggerCondition::PriceAbove,
+        &1_100_000_000i128,
+        &1_300_000_000i128,
+        &100_000i128,
+    );
+
+    let result = client.execute_trigger(&keeper, &trigger.id, &1_200_000_000i128);
+    assert_eq!(result.proceeds, 120_000);
+    assert!(!client.get_trigger(&trigger.id).unwrap().active);
+}
+
+#[test]
+fn execute_without_breach_keeps_trigger_active_and_untouched() {
+    let (env, client, oracle_client, _) = setup();
+    let handler = client.address.clone();
+    let owner = Address::generate(&env);
+    let keeper = Address::generate(&env);
+    let sell_issuer = Address::generate(&env);
+    let buy_issuer = Address::generate(&env);
+    let sell_asset = env.register_stellar_asset_contract(sell_issuer);
+    let buy_asset = env.register_stellar_asset_contract(buy_issuer);
+    mint(&env, &sell_asset, &owner, 1_000);
+    mint(&env, &buy_asset, &handler, 500_000);
+
+    // TWAP = 1.30e9 is ABOVE the 1.20e9 stop → no breach for PriceBelow.
+    seed_twap(
+        &oracle_client,
+        &symbol_short!("NGN"),
+        &[1_300_000_000, 1_300_000_000, 1_300_000_000],
+    );
+
+    let trigger = register_standard_trigger(&client, &owner, &sell_asset, &buy_asset);
+
+    let result = client.try_execute_trigger(&keeper, &trigger.id, &1_300_000_000i128);
+    assert_eq!(result, Err(Ok(ContractError::TriggerConditionNotMet)));
+
+    assert!(client.get_trigger(&trigger.id).unwrap().active);
+    assert_eq!(balance(&env, &buy_asset, &owner), 0);
+    assert_eq!(balance(&env, &sell_asset, &handler), 1_000);
+}
+
+#[test]
+fn keeper_claimed_price_must_match_verified_twap() {
+    let (env, client, oracle_client, _) = setup();
+    let handler = client.address.clone();
+    let owner = Address::generate(&env);
+    let keeper = Address::generate(&env);
+    let sell_issuer = Address::generate(&env);
+    let buy_issuer = Address::generate(&env);
+    let sell_asset = env.register_stellar_asset_contract(sell_issuer);
+    let buy_asset = env.register_stellar_asset_contract(buy_issuer);
+    mint(&env, &sell_asset, &owner, 1_000);
+    mint(&env, &buy_asset, &handler, 500_000);
+
+    seed_twap(
+        &oracle_client,
+        &symbol_short!("NGN"),
+        &[1_000_000_000, 1_000_000_000, 1_000_000_000],
+    );
+
+    let trigger = register_standard_trigger(&client, &owner, &sell_asset, &buy_asset);
+
+    // Keeper quotes a stale/fabricated price one unit off the verified TWAP.
+    let result = client.try_execute_trigger(&keeper, &trigger.id, &1_000_000_001i128);
+    assert_eq!(result, Err(Ok(ContractError::TriggerPriceNotVerified)));
+
+    assert!(client.get_trigger(&trigger.id).unwrap().active);
+    assert_eq!(balance(&env, &buy_asset, &owner), 0);
+}
+
+#[test]
+fn execute_without_oracle_data_fails_cleanly() {
+    let (env, client, _, _) = setup();
+    let owner = Address::generate(&env);
+    let keeper = Address::generate(&env);
+    let sell_issuer = Address::generate(&env);
+    let buy_issuer = Address::generate(&env);
+    let sell_asset = env.register_stellar_asset_contract(sell_issuer);
+    let buy_asset = env.register_stellar_asset_contract(buy_issuer);
+    mint(&env, &sell_asset, &owner, 1_000);
+
+    // Feed "UNFED" has no TWAP buffer at all.
+    let trigger = client.register_trigger(
+        &owner,
+        &sell_asset,
+        &buy_asset,
+        &symbol_short!("UNFED"),
+        &1_000i128,
+        &1_200_000_000i128,
+        &TriggerCondition::PriceBelow,
+        &900_000_000i128,
+        &1_100_000_000i128,
+        &0i128,
+    );
+
+    let result = client.try_execute_trigger(&keeper, &trigger.id, &1_000_000_000i128);
+    assert_eq!(result, Err(Ok(ContractError::OraclePriceUnavailable)));
+    assert!(client.get_trigger(&trigger.id).unwrap().active);
+}
+
+#[test]
+fn fill_price_above_max_fill_price_reverts_with_slippage() {
+    let (env, client, oracle_client, _) = setup();
+    let handler = client.address.clone();
+    let owner = Address::generate(&env);
+    let keeper = Address::generate(&env);
+    let sell_issuer = Address::generate(&env);
+    let buy_issuer = Address::generate(&env);
+    let sell_asset = env.register_stellar_asset_contract(sell_issuer);
+    let buy_asset = env.register_stellar_asset_contract(buy_issuer);
+    mint(&env, &sell_asset, &owner, 1_000);
+    mint(&env, &buy_asset, &handler, 500_000);
+
+    // TWAP = 1.10e9 breaches the 1.20e9 stop.
+    seed_twap(
+        &oracle_client,
+        &symbol_short!("NGN"),
+        &[1_100_000_000, 1_100_000_000, 1_100_000_000],
+    );
+
+    // max_fill_price = 1.00e9 < fill 1.10e9 → fill price exceeds the bound.
+    let trigger = client.register_trigger(
+        &owner,
+        &sell_asset,
+        &buy_asset,
+        &symbol_short!("NGN"),
+        &1_000i128,
+        &1_200_000_000i128,
+        &TriggerCondition::PriceBelow,
+        &900_000_000i128,
+        &1_000_000_000i128,
+        &0i128,
+    );
+
+    let result = client.try_execute_trigger(&keeper, &trigger.id, &1_100_000_000i128);
+    assert_eq!(result, Err(Ok(ContractError::SlippageExceeded)));
+
+    // The revert must leave every piece of state untouched.
+    assert!(client.get_trigger(&trigger.id).unwrap().active);
+    assert_eq!(balance(&env, &buy_asset, &owner), 0);
+    assert_eq!(balance(&env, &sell_asset, &handler), 1_000);
+}
+
+#[test]
+fn fill_price_below_min_fill_price_reverts_with_slippage() {
+    let (env, client, oracle_client, _) = setup();
+    let handler = client.address.clone();
+    let owner = Address::generate(&env);
+    let keeper = Address::generate(&env);
+    let sell_issuer = Address::generate(&env);
+    let buy_issuer = Address::generate(&env);
+    let sell_asset = env.register_stellar_asset_contract(sell_issuer);
+    let buy_asset = env.register_stellar_asset_contract(buy_issuer);
+    mint(&env, &sell_asset, &owner, 1_000);
+    mint(&env, &buy_asset, &handler, 500_000);
+
+    seed_twap(
+        &oracle_client,
+        &symbol_short!("NGN"),
+        &[1_000_000_000, 1_000_000_000, 1_000_000_000],
+    );
+
+    // min_fill_price = 1.05e9 > fill 1.00e9 → fill price falls below the floor.
+    let trigger = client.register_trigger(
+        &owner,
+        &sell_asset,
+        &buy_asset,
+        &symbol_short!("NGN"),
+        &1_000i128,
+        &1_200_000_000i128,
+        &TriggerCondition::PriceBelow,
+        &1_050_000_000i128,
+        &1_200_000_000i128,
+        &0i128,
+    );
+
+    let result = client.try_execute_trigger(&keeper, &trigger.id, &1_000_000_000i128);
+    assert_eq!(result, Err(Ok(ContractError::SlippageExceeded)));
+    assert!(client.get_trigger(&trigger.id).unwrap().active);
+}
+
+#[test]
+fn proceeds_below_min_amount_out_reverts_with_slippage() {
+    let (env, client, oracle_client, _) = setup();
+    let handler = client.address.clone();
+    let owner = Address::generate(&env);
+    let keeper = Address::generate(&env);
+    let sell_issuer = Address::generate(&env);
+    let buy_issuer = Address::generate(&env);
+    let sell_asset = env.register_stellar_asset_contract(sell_issuer);
+    let buy_asset = env.register_stellar_asset_contract(buy_issuer);
+    mint(&env, &sell_asset, &owner, 1_000);
+    mint(&env, &buy_asset, &handler, 500_000);
+
+    seed_twap(
+        &oracle_client,
+        &symbol_short!("NGN"),
+        &[1_000_000_000, 1_000_000_000, 1_000_000_000],
+    );
+
+    // Proceeds would be 100_000, but the owner demands at least 150_000.
+    let trigger = client.register_trigger(
+        &owner,
+        &sell_asset,
+        &buy_asset,
+        &symbol_short!("NGN"),
+        &1_000i128,
+        &1_200_000_000i128,
+        &TriggerCondition::PriceBelow,
+        &900_000_000i128,
+        &1_100_000_000i128,
+        &150_000i128,
+    );
+
+    let result = client.try_execute_trigger(&keeper, &trigger.id, &1_000_000_000i128);
+    assert_eq!(result, Err(Ok(ContractError::SlippageExceeded)));
+    assert!(client.get_trigger(&trigger.id).unwrap().active);
+    assert_eq!(balance(&env, &buy_asset, &owner), 0);
+}
+
+#[test]
+fn second_execution_is_rejected() {
+    let (env, client, oracle_client, _) = setup();
+    let handler = client.address.clone();
+    let owner = Address::generate(&env);
+    let keeper = Address::generate(&env);
+    let sell_issuer = Address::generate(&env);
+    let buy_issuer = Address::generate(&env);
+    let sell_asset = env.register_stellar_asset_contract(sell_issuer);
+    let buy_asset = env.register_stellar_asset_contract(buy_issuer);
+    mint(&env, &sell_asset, &owner, 1_000);
+    mint(&env, &buy_asset, &handler, 500_000);
+
+    seed_twap(
+        &oracle_client,
+        &symbol_short!("NGN"),
+        &[1_000_000_000, 1_000_000_000, 1_000_000_000],
+    );
+
+    let trigger = register_standard_trigger(&client, &owner, &sell_asset, &buy_asset);
+    client.execute_trigger(&keeper, &trigger.id, &1_000_000_000i128);
+
+    let replay = client.try_execute_trigger(&keeper, &trigger.id, &1_000_000_000i128);
+    assert_eq!(replay, Err(Ok(ContractError::TriggerNotActive)));
+
+    // No double payout: the owner still only received the first fill.
+    assert_eq!(balance(&env, &buy_asset, &owner), 100_000);
+}
+
+#[test]
+fn insufficient_pool_liquidity_reverts_and_keeps_trigger_active() {
+    let (env, client, oracle_client, _) = setup();
+    let handler = client.address.clone();
+    let owner = Address::generate(&env);
+    let keeper = Address::generate(&env);
+    let sell_issuer = Address::generate(&env);
+    let buy_issuer = Address::generate(&env);
+    let sell_asset = env.register_stellar_asset_contract(sell_issuer);
+    let buy_asset = env.register_stellar_asset_contract(buy_issuer);
+    mint(&env, &sell_asset, &owner, 1_000);
+    // Pool holds only 10_000 — less than the 100_000 proceeds.
+    mint(&env, &buy_asset, &handler, 10_000);
+
+    seed_twap(
+        &oracle_client,
+        &symbol_short!("NGN"),
+        &[1_000_000_000, 1_000_000_000, 1_000_000_000],
+    );
+
+    let trigger = register_standard_trigger(&client, &owner, &sell_asset, &buy_asset);
+
+    let result = client.try_execute_trigger(&keeper, &trigger.id, &1_000_000_000i128);
+    assert_eq!(result, Err(Ok(ContractError::InsufficientLiquidity)));
+    assert!(client.get_trigger(&trigger.id).unwrap().active);
+    assert_eq!(balance(&env, &buy_asset, &owner), 0);
+
+    // Top the pool up and the same trigger now executes cleanly.
+    let funder = Address::generate(&env);
+    mint(&env, &buy_asset, &funder, 200_000);
+    client.fund_pool(&funder, &buy_asset, &200_000i128);
+
+    let result = client.execute_trigger(&keeper, &trigger.id, &1_000_000_000i128);
+    assert_eq!(result.proceeds, 100_000);
+    assert_eq!(balance(&env, &buy_asset, &owner), 100_000);
+}
+
+#[test]
+fn cancel_refunds_escrow_and_blocks_execution() {
+    let (env, client, oracle_client, _) = setup();
+    let handler = client.address.clone();
+    let owner = Address::generate(&env);
+    let keeper = Address::generate(&env);
+    let sell_issuer = Address::generate(&env);
+    let buy_issuer = Address::generate(&env);
+    let sell_asset = env.register_stellar_asset_contract(sell_issuer);
+    let buy_asset = env.register_stellar_asset_contract(buy_issuer);
+    mint(&env, &sell_asset, &owner, 1_000);
+    mint(&env, &buy_asset, &handler, 500_000);
+
+    seed_twap(
+        &oracle_client,
+        &symbol_short!("NGN"),
+        &[1_000_000_000, 1_000_000_000, 1_000_000_000],
+    );
+
+    let trigger = register_standard_trigger(&client, &owner, &sell_asset, &buy_asset);
+
+    let refund = client.cancel_trigger(&owner, &trigger.id);
+    assert_eq!(refund, 1_000);
+    assert_eq!(balance(&env, &sell_asset, &owner), 1_000);
+    assert!(!client.get_trigger(&trigger.id).unwrap().active);
+
+    let result = client.try_execute_trigger(&keeper, &trigger.id, &1_000_000_000i128);
+    assert_eq!(result, Err(Ok(ContractError::TriggerNotActive)));
+    assert_eq!(balance(&env, &buy_asset, &owner), 0);
+}
+
+#[test]
+fn non_owner_cannot_cancel_trigger() {
+    let (env, client, _, _) = setup();
+    let handler = client.address.clone();
+    let owner = Address::generate(&env);
+    let attacker = Address::generate(&env);
+    let sell_issuer = Address::generate(&env);
+    let buy_issuer = Address::generate(&env);
+    let sell_asset = env.register_stellar_asset_contract(sell_issuer);
+    let buy_asset = env.register_stellar_asset_contract(buy_issuer);
+    mint(&env, &sell_asset, &owner, 1_000);
+
+    let trigger = register_standard_trigger(&client, &owner, &sell_asset, &buy_asset);
+
+    let result = client.try_cancel_trigger(&attacker, &trigger.id);
+    assert_eq!(result, Err(Ok(ContractError::NotTriggerOwner)));
+    assert!(client.get_trigger(&trigger.id).unwrap().active);
+    assert_eq!(balance(&env, &sell_asset, &handler), 1_000);
+}
+
+#[test]
+fn unknown_trigger_id_fails() {
+    let (env, client, _, _) = setup();
+    let keeper = Address::generate(&env);
+
+    let exec = client.try_execute_trigger(&keeper, &42u64, &1_000_000_000i128);
+    assert_eq!(exec, Err(Ok(ContractError::TriggerNotFound)));
+
+    let cancel = client.try_cancel_trigger(&keeper, &42u64);
+    assert_eq!(cancel, Err(Ok(ContractError::TriggerNotFound)));
+}
+
+#[test]
+fn any_keeper_may_execute() {
+    let (env, client, oracle_client, _) = setup();
+    let handler = client.address.clone();
+    let owner = Address::generate(&env);
+    // Keeper is an unrelated third party, not the owner.
+    let keeper = Address::generate(&env);
+    let sell_issuer = Address::generate(&env);
+    let buy_issuer = Address::generate(&env);
+    let sell_asset = env.register_stellar_asset_contract(sell_issuer);
+    let buy_asset = env.register_stellar_asset_contract(buy_issuer);
+    mint(&env, &sell_asset, &owner, 1_000);
+    mint(&env, &buy_asset, &handler, 500_000);
+
+    seed_twap(
+        &oracle_client,
+        &symbol_short!("NGN"),
+        &[1_000_000_000, 1_000_000_000, 1_000_000_000],
+    );
+
+    let trigger = register_standard_trigger(&client, &owner, &sell_asset, &buy_asset);
+    let result = client.execute_trigger(&keeper, &trigger.id, &1_000_000_000i128);
+    assert_eq!(result.proceeds, 100_000);
+    assert_eq!(balance(&env, &buy_asset, &owner), 100_000);
+}
+
+#[test]
+fn execution_emits_registration_and_execution_events() {
+    let (env, client, oracle_client, _) = setup();
+    let handler = client.address.clone();
+    let owner = Address::generate(&env);
+    let keeper = Address::generate(&env);
+    let sell_issuer = Address::generate(&env);
+    let buy_issuer = Address::generate(&env);
+    let sell_asset = env.register_stellar_asset_contract(sell_issuer);
+    let buy_asset = env.register_stellar_asset_contract(buy_issuer);
+    mint(&env, &sell_asset, &owner, 1_000);
+    mint(&env, &buy_asset, &handler, 500_000);
+
+    seed_twap(
+        &oracle_client,
+        &symbol_short!("NGN"),
+        &[1_000_000_000, 1_000_000_000, 1_000_000_000],
+    );
+
+    let trigger = register_standard_trigger(&client, &owner, &sell_asset, &buy_asset);
+    client.execute_trigger(&keeper, &trigger.id, &1_000_000_000i128);
+
+    assert!(event_has_topic(&env, &symbol_short!("trig_reg")));
+    assert!(event_has_topic(&env, &symbol_short!("trig_exec")));
+}
+
+#[test]
+fn cancel_emits_cancellation_event() {
+    let (env, client, _, _) = setup();
+    let owner = Address::generate(&env);
+    let sell_issuer = Address::generate(&env);
+    let buy_issuer = Address::generate(&env);
+    let sell_asset = env.register_stellar_asset_contract(sell_issuer);
+    let buy_asset = env.register_stellar_asset_contract(buy_issuer);
+    mint(&env, &sell_asset, &owner, 1_000);
+
+    let trigger = register_standard_trigger(&client, &owner, &sell_asset, &buy_asset);
+    client.cancel_trigger(&owner, &trigger.id);
+
+    assert!(event_has_topic(&env, &symbol_short!("trig_cxl")));
+}
+
+#[test]
+fn fund_pool_adds_liquidity_and_rejects_zero() {
+    let (env, client, _, _) = setup();
+    let funder = Address::generate(&env);
+    let issuer = Address::generate(&env);
+    let asset = env.register_stellar_asset_contract(issuer);
+    mint(&env, &asset, &funder, 5_000);
+
+    assert_eq!(client.get_pool_balance(&asset), 0);
+    client.fund_pool(&funder, &asset, &5_000i128);
+    assert_eq!(client.get_pool_balance(&asset), 5_000);
+    assert_eq!(balance(&env, &asset, &funder), 0);
+
+    let zero = client.try_fund_pool(&funder, &asset, &0i128);
+    assert_eq!(zero, Err(Ok(ContractError::InvalidAmount)));
+}


### PR DESCRIPTION
## Summary

Implements the stop-loss execution trigger contract handler described in #730: a conditional execution wrapper that swaps user positions when the verified TWAP oracle price crosses a target threshold.

Closes #730

## Implementation

New workspace contract \contracts/stop-loss-trigger\:

- **\egister_trigger\** — users post a trigger, escrowing \sell_asset\ with a stop price, direction (\PriceBelow\ for stop-loss, \PriceAbove\ for the mirror case), and user-configured slippage bounds (\min_fill_price\, \max_fill_price\, \min_amount_out\).
- **\execute_trigger\** — keeper entrypoint that never trusts keeper input:
  1. Reads the verified TWAP straight from the registered price oracle via a cross-contract \get_twap\ call (the same interface the workspace \price-oracle\ contract exposes).
  2. Validates the keeper submission: \claimed_twap\ must equal the on-chain TWAP or the call reverts with \TriggerPriceNotVerified\.
  3. Executes the market swap atomically when the stop-loss price condition is breached.
  4. Reverts with \SlippageExceeded\ when the resulting fill price (or proceeds) exceeds the slippage bounds configured by the user.
- **\cancel_trigger\** — owner-only refund of unfired escrows; **\und_pool\** — permissionless pool liquidity for settlement.

## Tests

22 tests covering: breach execution and balance movement, inclusive stop-price boundary, both trigger directions, keeper price-validation reverts, missing oracle data, fill-price/proceeds slippage reverts (with full state-preservation assertions), replay protection, insufficient pool liquidity (and recovery after funding), cancel/refund + non-owner cancel, invalid registration params, permissionless keeper execution, and event emission.

\cargo test -p stop-loss-trigger\ → 22 passed; \cargo build -p stop-loss-trigger --target wasm32-unknown-unknown --release\ → ok; \cargo clippy -p stop-loss-trigger --all-targets\ → clean; \cargo fmt --check\ → clean.

## Note on pre-existing state

The main crate (\stellarflow-contracts\ at \src/\) currently does not compile on \main\ (pre-existing merge corruption: duplicate items/imports, missing functions across ~34 files) — unrelated to this PR. This implementation is delivered as a self-contained workspace member following the \contracts/*\ convention (same template as \price-oracle\, \gas-tank\, etc.) so it builds and tests independently of that breakage.