### PR TITLE
feat: enforce atomic private-transfer nullifier consumption

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -326,6 +326,19 @@ pub struct TimeLockedUpgradeContract;
 
 #[contractimpl]
 impl TimeLockedUpgradeContract {
+    /// Atomically consume a nullifier for a private transfer.
+    ///
+    /// The persistent key is checked and written in this invocation, so a
+    /// replay returns before any caller-supplied transfer side effect runs.
+    pub fn consume_private_transfer_nullifier(
+        env: Env,
+        caller: Address,
+        nullifier: BytesN<32>,
+    ) -> Result<(), ContractError> {
+        caller.require_auth();
+        crate::zk::nullifier::register_nullifier(&env, nullifier)
+    }
+
     pub fn initialize(env: Env, admin: Address, treasury: Address) -> Result<(), ContractError> {
         ensure_schema_version(&env)?;
         if env.storage().instance().has(&DATA_KEY) {


### PR DESCRIPTION
Closes #784

## Summary
- expose an authenticated private-transfer nullifier consumption entrypoint
- reuse the persistent nullifier set so duplicate/replayed hashes return `NullifierAlreadyUsed` before downstream side effects
- retain the existing focused duplicate-nullifier regression test

## Verification
- Focused Rust test could not complete because the base branch currently fails compilation independently, including duplicate modules/imports, duplicate error variants, and malformed merged function bodies.
- No CI result is being claimed; the base branch must be repaired before this PR can be validated end-to-end.