### PR TITLE
feat: add automated vault liquidation engine

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1341,6 +1341,27 @@ impl TimeLockedUpgradeContract {
         vaults::autocompound::get_share_balance(&env, holder)
     }
 
+    /// Evaluate a vault liquidation against verified TWAP prices from the
+    /// oracle. Liquidation is allowed below 110% collateralization and
+    /// allocates 5% of confiscated collateral to the liquidator.
+    pub fn vault_liquidation_quote(
+        env: Env,
+        oracle: Address,
+        collateral_asset: Symbol,
+        debt_asset: Symbol,
+        position: vaults::liquidation::VaultPosition,
+        purchase_collateral: u128,
+    ) -> Result<vaults::liquidation::LiquidationResult, ContractError> {
+        vaults::liquidation::liquidate_at_twap(
+            &env,
+            &oracle,
+            &collateral_asset,
+            &debt_asset,
+            &position,
+            purchase_collateral,
+        )
+    }
+
     pub fn vault_config(env: Env) -> Option<vaults::autocompound::VaultConfig> {
         vaults::autocompound::get_config(&env)
     }

--- a/src/vaults/liquidation.rs
+++ b/src/vaults/liquidation.rs
@@ -1,13 +1,23 @@
-use soroban_sdk::{contracttype, Address, Env};
+use soroban_sdk::{contracttype, symbol_short, Address, Env, IntoVal, Symbol};
 
 use crate::ContractError;
+
+/// Basis-point denominator used by collateral ratios.
+pub const BPS_DENOMINATOR: u128 = 10_000;
+/// A vault is eligible for liquidation below 110% collateralization.
+pub const DEFAULT_LIQUIDATION_THRESHOLD_BPS: u32 = 11_000;
+/// Liquidators receive 5% of the confiscated collateral.
+pub const LIQUIDATOR_BONUS_BPS: u32 = 500;
 
 #[contracttype]
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct VaultPosition {
     pub owner: Address,
+    /// Collateral amount, or its value when prices have already been applied.
     pub collateral_value: u128,
+    /// Configured liquidation threshold in basis points. Zero uses 110%.
     pub liquidation_threshold_bps: u32,
+    /// Debt amount, or its value when prices have already been applied.
     pub borrowed_value: u128,
 }
 
@@ -15,6 +25,7 @@ pub struct VaultPosition {
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct LiquidationResult {
     pub liquidated: bool,
+    /// Collateralization ratio in basis points (10_000 == 100%).
     pub health_factor: u128,
     pub liquidator_reward: u128,
     pub protocol_reserve: u128,
@@ -24,11 +35,21 @@ pub fn health_factor(position: &VaultPosition) -> Result<u128, ContractError> {
     if position.borrowed_value == 0 {
         return Ok(u128::MAX);
     }
-    let numerator = position
+
+    position
         .collateral_value
-        .checked_mul(position.liquidation_threshold_bps as u128)
-        .ok_or(ContractError::MathOverflow)?;
-    Ok(numerator / position.borrowed_value / 10_000)
+        .checked_mul(BPS_DENOMINATOR)
+        .ok_or(ContractError::MathOverflow)?
+        .checked_div(position.borrowed_value)
+        .ok_or(ContractError::DivisionByZero)
+}
+
+fn threshold(position: &VaultPosition) -> u128 {
+    if position.liquidation_threshold_bps == 0 {
+        DEFAULT_LIQUIDATION_THRESHOLD_BPS as u128
+    } else {
+        position.liquidation_threshold_bps as u128
+    }
 }
 
 pub fn liquidate(
@@ -37,7 +58,7 @@ pub fn liquidate(
     purchase_collateral: u128,
 ) -> Result<LiquidationResult, ContractError> {
     let hf = health_factor(position)?;
-    if hf >= 1 {
+    if hf >= threshold(position) {
         return Ok(LiquidationResult {
             liquidated: false,
             health_factor: hf,
@@ -46,13 +67,67 @@ pub fn liquidate(
         });
     }
 
-    let reward = purchase_collateral / 20;
+    let reward = purchase_collateral
+        .checked_mul(LIQUIDATOR_BONUS_BPS as u128)
+        .ok_or(ContractError::MathOverflow)?
+        .checked_div(BPS_DENOMINATOR)
+        .ok_or(ContractError::DivisionByZero)?;
+    let protocol_reserve = purchase_collateral
+        .checked_sub(reward)
+        .ok_or(ContractError::MathOverflow)?;
+
     Ok(LiquidationResult {
         liquidated: true,
         health_factor: hf,
         liquidator_reward: reward,
-        protocol_reserve: purchase_collateral - reward,
+        protocol_reserve,
     })
+}
+
+/// Price a vault using the oracle's verified `get_twap(Symbol)` feed before
+/// applying the liquidation rule. Missing, stale, or invalid feeds fail
+/// closed; a caller cannot provide a fabricated price.
+pub fn liquidate_at_twap(
+    env: &Env,
+    oracle: &Address,
+    collateral_asset: &Symbol,
+    debt_asset: &Symbol,
+    position: &VaultPosition,
+    purchase_collateral: u128,
+) -> Result<LiquidationResult, ContractError> {
+    let collateral_price = read_twap(env, oracle, collateral_asset)?;
+    let debt_price = read_twap(env, oracle, debt_asset)?;
+    if collateral_price <= 0 || debt_price <= 0 {
+        return Err(ContractError::NotInitialized);
+    }
+
+    let collateral_value = position
+        .collateral_value
+        .checked_mul(collateral_price as u128)
+        .ok_or(ContractError::MathOverflow)?;
+    let borrowed_value = position
+        .borrowed_value
+        .checked_mul(debt_price as u128)
+        .ok_or(ContractError::MathOverflow)?;
+    let priced_position = VaultPosition {
+        collateral_value,
+        borrowed_value,
+        ..position.clone()
+    };
+
+    liquidate(env, &priced_position, purchase_collateral)
+}
+
+fn read_twap(env: &Env, oracle: &Address, asset: &Symbol) -> Result<i128, ContractError> {
+    let result: Result<Option<i128>, soroban_sdk::Error> = env.invoke_contract(
+        oracle,
+        &symbol_short!("get_twap"),
+        soroban_sdk::vec![env, asset.into_val(env)],
+    );
+    match result {
+        Ok(Some(price)) => Ok(price),
+        _ => Err(ContractError::NotInitialized),
+    }
 }
 
 #[cfg(test)]
@@ -60,19 +135,37 @@ mod tests {
     use super::*;
     use soroban_sdk::testutils::Address as _;
 
+    fn position(env: &Env, collateral: u128, debt: u128) -> VaultPosition {
+        VaultPosition {
+            owner: Address::generate(env),
+            collateral_value: collateral,
+            liquidation_threshold_bps: DEFAULT_LIQUIDATION_THRESHOLD_BPS,
+            borrowed_value: debt,
+        }
+    }
+
     #[test]
-    fn calculates_health_factor_and_liquidation() {
+    fn calculates_ratio_without_integer_truncation() {
         let env = Env::default();
-        let position = VaultPosition {
-            owner: Address::generate(&env),
-            collateral_value: 100,
-            liquidation_threshold_bps: 5_000,
-            borrowed_value: 60,
-        };
-        assert!(health_factor(&position).unwrap() < 1);
-        let result = liquidate(&env, &position, 100).unwrap();
+        assert_eq!(health_factor(&position(&env, 109, 100)).unwrap(), 10_900);
+        assert_eq!(health_factor(&position(&env, 110, 100)).unwrap(), 11_000);
+    }
+
+    #[test]
+    fn liquidates_below_110_percent_and_splits_five_percent_bonus() {
+        let env = Env::default();
+        let result = liquidate(&env, &position(&env, 109, 100), 100).unwrap();
         assert!(result.liquidated);
+        assert_eq!(result.health_factor, 10_900);
         assert_eq!(result.liquidator_reward, 5);
         assert_eq!(result.protocol_reserve, 95);
+    }
+
+    #[test]
+    fn does_not_liquidate_at_or_above_threshold() {
+        let env = Env::default();
+        let result = liquidate(&env, &position(&env, 110, 100), 100).unwrap();
+        assert!(!result.liquidated);
+        assert_eq!(result.liquidator_reward, 0);
     }
 }


### PR DESCRIPTION
## Overview

Add an automated vault-liquidation engine that evaluates collateral health using verified TWAP prices, liquidates positions below 110% collateralization, and allocates a 5% bonus to the liquidator.

## Related Issue

Closes #762

## Changes

### ⚡ Automated Liquidation Engine

* **[MODIFY]** Correct health-factor calculation to preserve collateral ratios in basis points (10,000 = 100%).
* **[ADD]** Read verified collateral and debt TWAPs through the oracle contract and fail closed when either feed is unavailable or invalid.
* **[ADD]** Apply the 110% liquidation boundary and split confiscated collateral into a 5% liquidator bonus and protocol reserve.
* **[ADD]** Expose `vault_liquidation_quote` through the main Soroban contract.
* **[ADD]** Cover below-threshold, boundary, ratio-precision, and bonus-allocation behavior with unit tests.

## Verification Results

```
git diff --check
# passed

rustfmt --edition 2021 src/vaults/liquidation.rs
# passed

cargo test --lib vaults::liquidation --offline
# attempted; Cargo compilation was blocked by the workspace build lock in this environment

cargo fmt --check
# blocked by the pre-existing syntax error in contracts/gas-tank/src/lib.rs
```

| Acceptance Criteria | Status |
| --- | --- |
| Read vault health using a live TWAP oracle price | ✅ Implemented via `get_twap` cross-contract reads |
| Trigger liquidation below 110% collateralization | ✅ Implemented with a 11,000 bps threshold |
| Pay the liquidator a 5% bonus from confiscated collateral | ✅ Implemented with checked basis-point arithmetic |

