### PR TITLE
Yield farm harvest-compound auto-router (#798)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,10 +31,20 @@ exclude = ["tests/fuzz/fuzz"]
 resolver = "2"
 
 [workspace.dependencies]
-soroban-sdk = { version = "=20.0.0", default-features = false, features = ["testutils"] }
+# Features named here are inherited by every member that writes
+# `soroban-sdk.workspace = true`, and a member's `default-features = false`
+# cannot drop them. Listing `testutils` here therefore forced it into the
+# *normal* dependency graph — including `ledger-time-helper`, which the root
+# crate depends on — and `testutils` needs `std` and `rand`, so the release
+# WASM build could not compile. Every member already asks for it explicitly in
+# its own [dev-dependencies].
+soroban-sdk = { version = "=20.0.0", default-features = false }
 
 [dependencies]
-soroban-sdk = { version = "=20.0.0", default-features = false, features = ["testutils"] }
+# No `testutils` here: it pulls in `std` and `rand`, which do not build for
+# wasm32-unknown-unknown, so enabling it in [dependencies] broke the release
+# WASM build outright. Tests get it from [dev-dependencies] below.
+soroban-sdk = { version = "=20.0.0", default-features = false }
 soroban-token-sdk = { version = "=20.0.0", default-features = false }
 ledger-time-helper = { path = "contracts/ledger-time-helper" }
 

--- a/src/bridge/mint.rs
+++ b/src/bridge/mint.rs
@@ -8,7 +8,7 @@
 //! rather than delegated to an external SEP-41 token, so the supply
 //! invariant can be enforced atomically in the same storage write.
 
-use soroban_sdk::{contracttype, Address, Env, Symbol};
+use soroban_sdk::{contracttype, symbol_short, Address, Env, Symbol};
 
 use crate::{ContractData, ContractError, DATA_KEY};
 
@@ -182,7 +182,6 @@ pub fn mint(
     save_config(env, &config);
 
     env.events().publish(
-        (Symbol::new(env, "WrappedTokenMinted"), asset_code, to.clone()),
         (symbol_short!("wtok_mnt"), asset_code.clone(), to.clone()),
         (amount, new_total_supply),
     );
@@ -233,7 +232,6 @@ pub fn burn(
     save_config(env, &config);
 
     env.events().publish(
-        (Symbol::new(env, "WrappedTokenBurned"), asset_code, from.clone()),
         (symbol_short!("wtok_brn"), asset_code.clone(), from.clone()),
         (amount, new_total_supply),
     );

--- a/src/escrow/merkle.rs
+++ b/src/escrow/merkle.rs
@@ -121,7 +121,7 @@ pub fn insert(env: &Env, commitment: BytesN<32>) -> Result<(u64, BytesN<32>), Co
     store_state(env, &state);
 
     env.events().publish(
-        (symbol_short!("merkle_add"),),
+        (soroban_sdk::Symbol::new(env, "merkle_add"),),
         (leaf_index, current.clone()),
     );
     Ok((leaf_index, current))

--- a/src/events/events.rs
+++ b/src/events/events.rs
@@ -416,10 +416,11 @@ mod tests {
         ];
         for name in names.iter() {
             assert!(
-                seen.try_insert(*name, ()).is_ok(),
+                !seen.contains_key(name.clone()),
                 "duplicate event name: {:?}",
                 name
             );
+            seen.set(name.clone(), ());
         }
     }
 

--- a/src/events/swaps.rs
+++ b/src/events/swaps.rs
@@ -56,6 +56,7 @@ pub fn publish_swap_executed(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use soroban_sdk::testutils::{Address as _, Events as _};
     use soroban_sdk::{symbol_short, Env};
 
     #[test]

--- a/src/kernel/budget.rs
+++ b/src/kernel/budget.rs
@@ -7,8 +7,8 @@ pub struct GasLogger;
 impl GasLogger {
     pub fn log_budget(env: &Env, function_name: &str) {
         let budget = env.budget();
-        let cpu = budget.cpu_instruction_count();
-        let mem = budget.memory_allocation();
+        let cpu = budget.cpu_instruction_cost();
+        let mem = budget.memory_bytes_cost();
 
         // Print budget logs
         budget.print();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -164,26 +164,15 @@ pub enum ContractError {
     InsufficientBondForPenalty = 46,
     SlippageExceeded = 47,
     AmountTooLow = 48,
-    NullifierAlreadyUsed = 48,
     InvalidProof = 49,
-    BridgeAssetNotRegistered = 50,
-    BridgeInvalidMaxSupply = 51,
-    BridgeAssetAlreadyRegistered = 52,
-    BridgeInvalidAmount = 53,
-    BridgeNotController = 54,
-    BridgeSupplyCapExceeded = 55,
-    BridgeInsufficientBalance = 56,
-    BridgeEscrowNotConfigured = 57,
     /// Reentrancy guard detected a reentrant call during execution.
     ReentrancyDetected = 58,
     MerkleTreeFull = 59,
-    NullifierAlreadyUsed = 49,
-    InvalidProof = 50,
-    ReentrancyDetected = 59,
 }
 
 impl ContractError {
     pub const MathOverflow: Self = Self::Overflow;
+    pub const NullifierAlreadyUsed: Self = Self::AlreadyRegistered;
     pub const BridgeAssetNotRegistered: Self = Self::NotRegistered;
     pub const BridgeInvalidMaxSupply: Self = Self::Overflow;
     pub const BridgeAssetAlreadyRegistered: Self = Self::AlreadyRegistered;
@@ -233,6 +222,11 @@ impl ContractError {
     pub const RoleExpirationInPast: Self = Self::UpgradeTimelockNotSatisfied;
     pub const RoleNotFound: Self = Self::NotRegistered;
     pub const RoleExpiredOrMissing: Self = Self::Unauthorized;
+    pub const HarvestNothingToCompound: Self = Self::AmountTooLow;
+    pub const HarvestInvalidMinOut: Self = Self::AmountTooLow;
+    pub const HarvestSwapFailed: Self = Self::RouteExecutionFailed;
+    pub const HarvestSlippageExceeded: Self = Self::SlippageExceeded;
+    pub const HarvestInvalidPath: Self = Self::InconsistentRouteAssets;
 }
 
 // Contract state keys
@@ -635,9 +629,10 @@ impl TimeLockedUpgradeContract {
         get_nonce(&env, &coordinator)
     }
 
-    pub fn get_last_update_timestamp(env: Env, asset: Symbol) -> Option<u64> {
-        let asset_id = symbol_to_asset_id(&asset);
-        let heartbeat_key = HeartbeatKey(asset_id);
+    /// Takes an `AssetId` like its siblings `update_heartbeat` and
+    /// `is_data_fresh`; callers hash a `Symbol` with `symbol_to_asset_id`.
+    pub fn get_last_update_timestamp(env: Env, asset: AssetId) -> Option<u64> {
+        let heartbeat_key = HeartbeatKey(asset);
         env.storage().temporary().get(&heartbeat_key)
     }
 
@@ -714,6 +709,16 @@ impl TimeLockedUpgradeContract {
 
     pub fn get_corridor_fee_pool(env: Env, asset: AssetId) -> fees::CorridorFeePool {
         crate::fees::get_corridor_fee_pool(env, asset)
+    }
+
+    pub fn add_corridor_fees(
+        env: Env,
+        admin: Address,
+        asset: AssetId,
+        collected: u64,
+        variable_fee: u64,
+    ) -> Result<fees::CorridorFeePool, ContractError> {
+        crate::fees::add_corridor_fees(env, admin, asset, collected, variable_fee)
     }
 
     pub fn record_lp_fee(
@@ -1401,6 +1406,31 @@ impl TimeLockedUpgradeContract {
         user: Address,
     ) -> Result<i128, ContractError> {
         vaults::lp_farming::pending_rewards(&env, user)
+    }
+
+    pub fn yield_farming_share_balance(env: Env, user: Address) -> i128 {
+        vaults::lp_farming::get_share_balance(&env, user)
+    }
+
+    // ── Yield farm harvest-compound auto-router (Issue #798) ─────────────────
+
+    /// Claim accrued farm rewards, swap them to LP through `router` along
+    /// `path`, and re-stake the proceeds — atomically. `min_lp_out` is the
+    /// caller's slippage floor, enforced against the vault's measured LP
+    /// balance delta rather than anything the router reports.
+    ///
+    /// The reentrancy guard here is the *only* one on this path: it must hold
+    /// across the untrusted `router` call, and the `lp_farming` helpers this
+    /// delegates to take no guard of their own.
+    pub fn harvest_and_compound(
+        env: Env,
+        user: Address,
+        router: Address,
+        path: Vec<Address>,
+        min_lp_out: i128,
+    ) -> Result<vaults::harvest_compound::HarvestCompoundResult, ContractError> {
+        let _guard = security::reentrancy::ReentrancyGuard::new(&env)?;
+        vaults::harvest_compound::harvest_and_compound(&env, user, router, path, min_lp_out)
     }
 
     // ── On-chain limit order book (Issue #701) ───────────────────────────────

--- a/src/recovery.rs
+++ b/src/recovery.rs
@@ -177,6 +177,7 @@ mod tests {
             let data = crate::ContractData {
                 admin: admin.clone(),
                 value: 0,
+                max_fee_ceiling: 0,
             };
             env.storage().instance().set(&crate::DATA_KEY, &data);
 
@@ -202,6 +203,7 @@ mod tests {
             let data = crate::ContractData {
                 admin: admin.clone(),
                 value: 0,
+                max_fee_ceiling: 0,
             };
             env.storage().instance().set(&crate::DATA_KEY, &data);
 
@@ -253,6 +255,7 @@ mod tests {
             let data = crate::ContractData {
                 admin: Address::generate(&env),
                 value: 0,
+                max_fee_ceiling: 0,
             };
             env.storage().instance().set(&crate::DATA_KEY, &data);
 
@@ -268,6 +271,7 @@ mod tests {
             let data = crate::ContractData {
                 admin: Address::generate(&env),
                 value: 0,
+                max_fee_ceiling: 0,
             };
             env.storage().instance().set(&crate::DATA_KEY, &data);
             env.storage().instance().set(&RECOVERY_KEY, &recovery_key);
@@ -285,6 +289,7 @@ mod tests {
             let data = crate::ContractData {
                 admin: Address::generate(&env),
                 value: 0,
+                max_fee_ceiling: 0,
             };
             env.storage().instance().set(&crate::DATA_KEY, &data);
             env.storage().instance().set(&RECOVERY_KEY, &recovery_key);
@@ -302,6 +307,7 @@ mod tests {
             let data = crate::ContractData {
                 admin: Address::generate(&env),
                 value: 0,
+                max_fee_ceiling: 0,
             };
             env.storage().instance().set(&crate::DATA_KEY, &data);
             env.storage().instance().set(&RECOVERY_KEY, &recovery_key);
@@ -319,6 +325,7 @@ mod tests {
             let data = crate::ContractData {
                 admin: Address::generate(&env),
                 value: 0,
+                max_fee_ceiling: 0,
             };
             env.storage().instance().set(&crate::DATA_KEY, &data);
             env.storage().instance().set(&RECOVERY_KEY, &recovery_key);
@@ -346,6 +353,7 @@ mod tests {
             let data = crate::ContractData {
                 admin: Address::generate(&env),
                 value: 0,
+                max_fee_ceiling: 0,
             };
             env.storage().instance().set(&crate::DATA_KEY, &data);
             env.storage().instance().set(&RECOVERY_KEY, &recovery_key);
@@ -368,6 +376,7 @@ mod tests {
             let data = crate::ContractData {
                 admin: recovery_key.clone(),
                 value: 0,
+                max_fee_ceiling: 0,
             };
             env.storage().instance().set(&crate::DATA_KEY, &data);
             env.storage().instance().set(&RECOVERY_KEY, &recovery_key);
@@ -391,6 +400,7 @@ mod tests {
             let data = crate::ContractData {
                 admin: admin.clone(),
                 value: 0,
+                max_fee_ceiling: 0,
             };
             env.storage().instance().set(&crate::DATA_KEY, &data);
 

--- a/src/security/pausable.rs
+++ b/src/security/pausable.rs
@@ -105,9 +105,9 @@ pub fn emergency_unpause(
 mod tests {
     use super::*;
     use soroban_sdk::testutils::{Address as _, Events};
-    use soroban_sdk::Env;
+    use soroban_sdk::{Env, IntoVal};
 
-    fn setup() -> (Env, Address, Address, Address) {
+    fn setup() -> (Env, Address, Address, Address, Address) {
         let env = Env::default();
         env.mock_all_auths();
         let admin = Address::generate(&env);
@@ -120,6 +120,7 @@ mod tests {
             let data = ContractData {
                 admin: admin.clone(),
                 value: 0,
+                max_fee_ceiling: 0,
             };
             env.storage().instance().set(&DATA_KEY, &data);
         });
@@ -210,8 +211,8 @@ mod tests {
 
             let events = env.events().all();
             let found = events.iter().any(|e| {
-                e.0 == (contract_id.clone(),)
-                    && e.1 == (Symbol::new(&env, "EMRG_PAUSE"),)
+                e.0 == contract_id
+                    && e.1 == soroban_sdk::vec![&env, Symbol::new(&env, "EMRG_PAUSE").into_val(&env)]
             });
             assert!(found, "should emit EMRG_PAUSE event");
         });
@@ -231,8 +232,8 @@ mod tests {
 
             let events = env.events().all();
             let found = events.iter().any(|e| {
-                e.0 == (contract_id.clone(),)
-                    && e.1 == (Symbol::new(&env, "EMRG_UNPAUSE"),)
+                e.0 == contract_id
+                    && e.1 == soroban_sdk::vec![&env, Symbol::new(&env, "EMRG_UNPAUSE").into_val(&env)]
             });
             assert!(found, "should emit EMRG_UNPAUSE event");
         });

--- a/src/staging.rs
+++ b/src/staging.rs
@@ -279,6 +279,7 @@ mod tests {
         let data = ContractData {
             admin: admin.clone(),
             value: 0,
+            max_fee_ceiling: 0,
         };
         env.storage().instance().set(&DATA_KEY, &data);
         (admin, treasury)

--- a/src/test.rs
+++ b/src/test.rs
@@ -101,11 +101,29 @@ fn test_schema_version_migration_converts_legacy_state() {
     assert_eq!(data.admin, admin);
     assert_eq!(data.value, 0);
 
-    assert!(env.storage().persistent().has(&crate::storage::NodeProfileKey(admin.clone())));
-    assert!(env.storage().instance().has(&crate::storage::SignerKey(admin.clone())));
-    assert!(env.storage().instance().has(&crate::storage::StakeKey(admin.clone())));
-    assert_eq!(env.storage().instance().get(&crate::TOTAL_STAKED_KEY).unwrap(), 123u64);
-    assert!(env.storage().temporary().has(&crate::storage::HeartbeatKey(0u32)));
+    assert!(env
+        .storage()
+        .persistent()
+        .has(&crate::storage::NodeProfileKey::ProfileByNode(admin.clone())));
+    assert!(env
+        .storage()
+        .instance()
+        .has(&crate::storage::SignerKey::SignerByAddress(admin.clone())));
+    assert!(env
+        .storage()
+        .instance()
+        .has(&crate::storage::StakeKey::StakeByNode(admin.clone())));
+    assert_eq!(
+        env.storage()
+            .instance()
+            .get::<_, u64>(&crate::TOTAL_STAKED_KEY)
+            .unwrap(),
+        123u64
+    );
+    assert!(env
+        .storage()
+        .temporary()
+        .has(&crate::storage::HeartbeatKey::HeartbeatByAsset(0u32)));
 }
 
 #[test]
@@ -1370,7 +1388,7 @@ fn test_timelock_path_rejected_before_delay() {
     client.propose_admin_change(&admin, &new_admin);
     // Attempt immediate execution without waiting
     let result = client.try_execute_admin_change_by_timelock(&admin);
-    assert_eq!(result, Err(Ok(ContractError::AdminChangeTimelockNotSatisfied)));
+    assert_eq!(result, Err(Ok(ContractError::AdminChangeTimelockNotSatis)));
 }
 
 #[test]

--- a/src/vaults/autocompound.rs
+++ b/src/vaults/autocompound.rs
@@ -74,7 +74,7 @@ pub fn flash_loan(env: &Env, borrower: Address, amount: i128) -> Result<i128, Co
     token_client.transfer(&env.current_contract_address(), &borrower, &amount);
     env.invoke_contract::<()>(
         &borrower,
-        &soroban_sdk::symbol_short!("on_flash_loan"),
+        &soroban_sdk::Symbol::new(env, "on_flash_loan"),
         soroban_sdk::vec![
             env,
             config.asset.into_val(env),
@@ -197,7 +197,9 @@ pub fn set_performance_fee(env: &Env, admin: Address, fee_bps: u32) -> Result<Va
 /// Deposit `amount` of the underlying asset and mint pro-rata `sfvToken`
 /// shares. The first depositor mints 1:1.
 pub fn deposit(env: &Env, depositor: Address, amount: i128) -> Result<i128, ContractError> {
-    let _guard = crate::security::reentrancy::ReentrancyGuard::new(env)?;
+    // No reentrancy guard here: the `vault_deposit` entry point in `lib.rs`
+    // already holds it for the whole call, and the lock is not re-entrant, so
+    // taking it twice made every deposit fail with `ReentrancyDetected`.
     if amount <= 0 {
         return Err(ContractError::VaultZeroAmount);
     }
@@ -246,7 +248,7 @@ pub fn deposit(env: &Env, depositor: Address, amount: i128) -> Result<i128, Cont
 
 /// Burn `shares` and withdraw the pro-rata amount of underlying asset.
 pub fn withdraw(env: &Env, owner: Address, shares: i128) -> Result<i128, ContractError> {
-    let _guard = crate::security::reentrancy::ReentrancyGuard::new(env)?;
+    // See `deposit`: the guard belongs to the `vault_withdraw` entry point.
     if shares <= 0 {
 
         return Err(ContractError::VaultZeroAmount);

--- a/src/vaults/harvest_compound.rs
+++ b/src/vaults/harvest_compound.rs
@@ -1,0 +1,650 @@
+//! Yield-farm harvest → swap → re-stake auto-router (Issue #798).
+//!
+//! [`harvest_and_compound`] is a single atomic vault entrypoint that turns a
+//! farmer's *accrued but unstaked* reward tokens into *additional staked LP*,
+//! in one transaction:
+//!
+//! 1. **Claim** — settle and withdraw the caller's pending emissions from the
+//!    [`crate::vaults::lp_farming`] pool (`reward_token`).
+//! 2. **Swap** — route that reward amount through an external DEX router along
+//!    a caller-supplied `path` that ends at the farm's `lp_token`.
+//! 3. **Re-stake** — deposit every LP token the swap produced back into the
+//!    same farm, raising the caller's share balance and therefore their
+//!    forward emission rate. That compounding is the whole point: rewards that
+//!    would have sat idle now earn emissions themselves.
+//!
+//! ## Why the route is caller-supplied
+//!
+//! There is no on-chain AMM in this contract, and the best venue for a
+//! `reward_token → lp_token` conversion changes block to block. Rather than
+//! pin a router into storage, every call names its own `router` and `path`, so
+//! an off-chain keeper can quote the market and hand in the best route it
+//! found — the "auto-router" of the issue title. Nothing about that is trusted:
+//! see the safety notes below.
+//!
+//! ## Router integration contract
+//!
+//! `router` must expose:
+//!
+//! ```text
+//! swap_exact_tokens_for_tokens(
+//!     amount_in: i128, amount_out_min: i128, path: Vec<Address>, to: Address,
+//! )
+//! ```
+//!
+//! This is the Uniswap-V2 / Soroswap signature. The vault transfers `amount_in`
+//! of `path[0]` to the router *before* the call (transfer-then-call), and the
+//! router must deliver the output of `path[last]` to `to`. Any return value is
+//! ignored.
+//!
+//! ## Safety
+//!
+//! The router is arbitrary caller-supplied code, so it is treated as hostile:
+//!
+//! * **Output is measured, never reported.** `lp_acquired` is the vault's own
+//!   `balance()` delta across the swap, not the router's return value. A router
+//!   that claims to have paid out cannot make the vault credit LP it did not
+//!   actually receive.
+//! * **Slippage is enforced locally.** `amount_out_min` is passed to the router
+//!   as `0` and the real check runs here against the measured delta, so a
+//!   router cannot satisfy the bound by lying about it. The caller's
+//!   `min_lp_out` is the only bound that binds.
+//! * **Re-entry is blocked.** The wrapper in `lib.rs` holds the contract-wide
+//!   [`crate::security::reentrancy::ReentrancyGuard`] for the duration, so a
+//!   router that calls back into the vault mid-swap aborts the transaction.
+//! * **Failure is atomic.** If the swap under-delivers, the whole transaction
+//!   reverts — including step 1 — so the caller's rewards are never consumed
+//!   without LP coming back. They stay claimable and the call can be retried
+//!   with a different route.
+//!
+//! ## Authorization
+//!
+//! This is not a permissionless keeper entry point: it moves `user`'s rewards
+//! and stakes on their behalf, so `user` must authorize the call.
+//!
+//! That authorization is asserted exactly once. Soroban permits a single
+//! `require_auth` per address per invocation frame — a second one aborts the
+//! host rather than returning an error — and this function runs
+//! [`lp_farming::claim_rewards`](crate::vaults::lp_farming::claim_rewards),
+//! which already requires it. Everything downstream therefore uses the
+//! pre-authorized variants (see
+//! [`lp_farming::stake_preauthorized`](crate::vaults::lp_farming::stake_preauthorized)).
+
+use soroban_sdk::{contracttype, token, Address, Env, IntoVal, Symbol, Val, Vec};
+
+use crate::{amm, vaults, ContractError};
+
+/// A swap path must name at least an input and an output token.
+pub const MIN_SWAP_PATH_LEN: u32 = 2;
+
+/// Upper bound on hops in a caller-supplied route. Routes longer than this are
+/// rejected outright rather than forwarded to the router, which keeps the
+/// unbounded `Vec` argument from being used to inflate the call's footprint.
+pub const MAX_SWAP_PATH_LEN: u32 = 8;
+
+/// Outcome of one [`harvest_and_compound`] round trip.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct HarvestCompoundResult {
+    /// Reward tokens claimed from the farm and fed into the swap.
+    pub reward_claimed: i128,
+    /// LP tokens the swap actually delivered, measured as a balance delta.
+    pub lp_acquired: i128,
+    /// The caller's farm share balance after the newly acquired LP was staked.
+    pub new_share_balance: i128,
+}
+
+/// Claim, swap, and re-stake in one atomic step. See the module docs for the
+/// router integration contract and the trust model.
+///
+/// # Errors
+/// * [`ContractError::VaultPaused`] / [`ContractError::ContractPaused`] — vault frozen.
+/// * [`ContractError::VaultNotInitialized`] — no yield farm configured.
+/// * [`ContractError::HarvestInvalidPath`] — `path` does not run `reward_token → lp_token`,
+///   or its length is outside [`MIN_SWAP_PATH_LEN`]..=[`MAX_SWAP_PATH_LEN`].
+/// * [`ContractError::HarvestInvalidMinOut`] — `min_lp_out` is negative.
+/// * [`ContractError::HarvestNothingToCompound`] — no rewards have accrued yet.
+/// * [`ContractError::HarvestSwapFailed`] — the router delivered no LP at all.
+/// * [`ContractError::HarvestSlippageExceeded`] — LP delivered was below `min_lp_out`.
+pub fn harvest_and_compound(
+    env: &Env,
+    user: Address,
+    router: Address,
+    path: Vec<Address>,
+    min_lp_out: i128,
+) -> Result<HarvestCompoundResult, ContractError> {
+    // Deliberately no `user.require_auth()` here: `lp_farming::claim_rewards`
+    // (step 1) already demands it, and calling `require_auth` twice for the
+    // same address within a single invocation frame aborts the host rather
+    // than returning an error. The caller's authorization is still mandatory —
+    // it is just asserted exactly once, by the first delegate that needs it.
+    vaults::pause_guard::require_vault_operational(env)?;
+
+    if min_lp_out < 0 {
+        return Err(ContractError::HarvestInvalidMinOut);
+    }
+
+    let farm = vaults::lp_farming::get_config(env).ok_or(ContractError::VaultNotInitialized)?;
+    validate_path(&path, &farm)?;
+
+    // ── 1. Claim ────────────────────────────────────────────────────────────
+    // `claim_rewards` settles the pool and pays the caller directly, so the
+    // reward lands in `user`'s balance and is pulled back into vault custody
+    // below. Routing it through the caller keeps `lp_farming` untouched.
+    let reward_claimed = vaults::lp_farming::claim_rewards(env, user.clone())?;
+    if reward_claimed <= 0 {
+        return Err(ContractError::HarvestNothingToCompound);
+    }
+
+    let vault = env.current_contract_address();
+    let reward_client = token::Client::new(env, &farm.reward_token);
+    let lp_client = token::Client::new(env, &farm.lp_token);
+
+    // ── 2. Swap ─────────────────────────────────────────────────────────────
+    // Transfer-then-call: the router is funded first, then invoked. Measure the
+    // LP balance *after* funding so the delta captures the swap alone and is
+    // unaffected by LP already staked in the vault by other farmers.
+    reward_client.transfer(&user, &vault, &reward_claimed);
+    reward_client.transfer(&vault, &router, &reward_claimed);
+
+    let lp_before = lp_client.balance(&vault);
+    let _: Val = env.invoke_contract(
+        &router,
+        &Symbol::new(env, "swap_exact_tokens_for_tokens"),
+        soroban_sdk::vec![
+            env,
+            reward_claimed.into_val(env),
+            // Deliberately 0: the binding slippage check is the measured one
+            // below, which a hostile router cannot talk its way past.
+            0i128.into_val(env),
+            path.into_val(env),
+            vault.clone().into_val(env),
+        ],
+    );
+    let lp_after = lp_client.balance(&vault);
+
+    let lp_acquired = lp_after
+        .checked_sub(lp_before)
+        .ok_or(ContractError::MathOverflow)?;
+    if lp_acquired <= 0 {
+        return Err(ContractError::HarvestSwapFailed);
+    }
+    // `min_lp_out` is non-negative (checked above) and `lp_acquired` is
+    // positive, so both casts are lossless.
+    amm::slippage::enforce_slippage(lp_acquired as u128, min_lp_out as u128)
+        .map_err(|_| ContractError::HarvestSlippageExceeded)?;
+
+    // ── 3. Re-stake ─────────────────────────────────────────────────────────
+    // `lp_farming::stake` pulls LP from the staker, so hand the swap proceeds
+    // to `user` first and let the farm draw them straight back in.
+    lp_client.transfer(&vault, &user, &lp_acquired);
+    // `stake_preauthorized`, not `stake`: step 1's `claim_rewards` already
+    // asserted `user`'s authorization for this frame.
+    vaults::lp_farming::stake_preauthorized(env, user.clone(), lp_acquired)?;
+    let new_share_balance = vaults::lp_farming::get_share_balance(env, user.clone());
+
+    env.events().publish(
+        (soroban_sdk::symbol_short!("hrvcmpnd"), user),
+        (reward_claimed, lp_acquired, new_share_balance),
+    );
+
+    Ok(HarvestCompoundResult {
+        reward_claimed,
+        lp_acquired,
+        new_share_balance,
+    })
+}
+
+/// A route is only usable if it converts exactly the farm's reward token into
+/// exactly the farm's LP token; anything else would swap the wrong asset or
+/// deliver something the farm cannot stake.
+fn validate_path(
+    path: &Vec<Address>,
+    farm: &vaults::lp_farming::FarmingConfig,
+) -> Result<(), ContractError> {
+    let len = path.len();
+    if !(MIN_SWAP_PATH_LEN..=MAX_SWAP_PATH_LEN).contains(&len) {
+        return Err(ContractError::HarvestInvalidPath);
+    }
+    if path.get(0) != Some(farm.reward_token.clone())
+        || path.get(len - 1) != Some(farm.lp_token.clone())
+    {
+        return Err(ContractError::HarvestInvalidPath);
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use soroban_sdk::testutils::{Address as _, Events, Ledger};
+    use soroban_sdk::{contract, contractimpl, symbol_short, IntoVal, TryFromVal};
+
+    // ── Test doubles for the external DEX router ────────────────────────────
+
+    const OUT_TOKEN: soroban_sdk::Symbol = symbol_short!("OUT");
+    const RATE_NUM: soroban_sdk::Symbol = symbol_short!("NUM");
+    const RATE_DEN: soroban_sdk::Symbol = symbol_short!("DEN");
+
+    /// Stand-in for the external DEX router: pays out `amount_in * num / den`
+    /// of `out_token` from its own float, then *lies* about the amount by
+    /// reporting `i128::MAX`. Every assertion on `lp_acquired` therefore proves
+    /// the vault trusted its measured balance delta and not this number.
+    #[contract]
+    pub struct MockRouter;
+
+    #[contractimpl]
+    impl MockRouter {
+        pub fn configure(env: Env, out_token: Address, num: i128, den: i128) {
+            env.storage().instance().set(&OUT_TOKEN, &out_token);
+            env.storage().instance().set(&RATE_NUM, &num);
+            env.storage().instance().set(&RATE_DEN, &den);
+        }
+
+        pub fn swap_exact_tokens_for_tokens(
+            env: Env,
+            amount_in: i128,
+            _amount_out_min: i128,
+            _path: Vec<Address>,
+            to: Address,
+        ) -> Vec<i128> {
+            let out: Address = env.storage().instance().get(&OUT_TOKEN).unwrap();
+            let num: i128 = env.storage().instance().get(&RATE_NUM).unwrap();
+            let den: i128 = env.storage().instance().get(&RATE_DEN).unwrap();
+            let amount_out = amount_in * num / den;
+            if amount_out > 0 {
+                token::Client::new(&env, &out).transfer(
+                    &env.current_contract_address(),
+                    &to,
+                    &amount_out,
+                );
+            }
+            soroban_sdk::vec![&env, amount_in, i128::MAX]
+        }
+    }
+
+    // ── Fixture ─────────────────────────────────────────────────────────────
+
+    /// Staked LP, chosen so `acc_reward_per_share` math stays exact.
+    const STAKE: i128 = 1_000_000;
+    /// Farm emission per ledger at the default 1x multiplier.
+    const EMISSION: i128 = 100;
+    /// Ledgers advanced before harvesting: `EMISSION * LEDGERS` rewards accrue.
+    const LEDGERS: u32 = 10;
+    /// Rewards the single staker is owed after `LEDGERS` ledgers.
+    const EXPECTED_REWARD: i128 = EMISSION * LEDGERS as i128; // 1_000
+
+    struct Fixture {
+        env: Env,
+        client: crate::TimeLockedUpgradeContractClient<'static>,
+        contract_id: Address,
+        admin: Address,
+        user: Address,
+        lp_token: Address,
+        reward_token: Address,
+    }
+
+    impl Fixture {
+        /// Route that actually converts the farm's reward token into its LP
+        /// token: the only shape `validate_path` accepts.
+        fn path(&self) -> Vec<Address> {
+            soroban_sdk::vec![
+                &self.env,
+                self.reward_token.clone(),
+                self.lp_token.clone()
+            ]
+        }
+
+        /// Register a [`MockRouter`] paying `num/den`, pre-funded with enough
+        /// LP to settle the swap.
+        fn router(&self, num: i128, den: i128) -> Address {
+            let router = self.env.register_contract(None, MockRouter);
+            MockRouterClient::new(&self.env, &router).configure(&self.lp_token, &num, &den);
+            mint(&self.env, &self.lp_token, &router, STAKE);
+            router
+        }
+    }
+
+    fn mint(env: &Env, asset: &Address, to: &Address, amount: i128) {
+        token::StellarAssetClient::new(env, asset).mint(to, &amount);
+    }
+
+    /// Advance the ledger by `count` sequence numbers.
+    ///
+    /// Reads the current `LedgerInfo` and edits it rather than constructing a
+    /// fresh one: a literal `LedgerInfo { .. }` also resets the entry-TTL
+    /// fields, and the mismatch against entries already written (the
+    /// Stellar-asset contracts registered during setup) makes every later
+    /// token call fail with `Error(Context, InternalError)` in this pinned
+    /// soroban-sdk 20.0.0 test harness.
+    fn advance_ledgers(env: &Env, count: u32) {
+        let mut info = env.ledger().get();
+        info.sequence_number += count;
+        info.timestamp += 5 * count as u64;
+        env.ledger().set(info);
+    }
+
+    /// Farm initialized, `user` fully staked, `LEDGERS` elapsed so exactly
+    /// `EXPECTED_REWARD` is claimable, and the reward pot funded.
+    fn setup() -> Fixture {
+        let env = Env::default();
+        env.mock_all_auths();
+
+        let contract_id = env.register_contract(None, crate::TimeLockedUpgradeContract);
+        let client = crate::TimeLockedUpgradeContractClient::new(&env, &contract_id);
+
+        let admin = Address::generate(&env);
+        let treasury = Address::generate(&env);
+        client.initialize(&admin, &treasury);
+
+        let issuer = Address::generate(&env);
+        let lp_token = env.register_stellar_asset_contract(issuer.clone());
+        let reward_token = env.register_stellar_asset_contract(issuer);
+
+        client.init_yield_farming(&admin, &lp_token, &reward_token, &EMISSION);
+
+        let user = Address::generate(&env);
+        mint(&env, &lp_token, &user, STAKE);
+        client.stake_lp(&user, &STAKE);
+
+        advance_ledgers(&env, LEDGERS);
+
+        // Fund the reward pot so `claim_rewards` has something to pay out.
+        let funder = Address::generate(&env);
+        mint(&env, &reward_token, &funder, EXPECTED_REWARD * 10);
+        client.fund_yield_rewards(&funder, &(EXPECTED_REWARD * 10));
+
+        Fixture {
+            env,
+            client,
+            contract_id,
+            admin,
+            user,
+            lp_token,
+            reward_token,
+        }
+    }
+
+    // ── Happy path ──────────────────────────────────────────────────────────
+
+    #[test]
+    fn compounds_rewards_into_additional_staked_lp() {
+        let f = setup();
+        assert_eq!(
+            f.client.pending_yield_rewards(&f.user),
+            EXPECTED_REWARD,
+            "fixture should have accrued exactly EXPECTED_REWARD"
+        );
+
+        // 1 reward token buys 2 LP tokens.
+        let router = f.router(2, 1);
+        let result = f
+            .client
+            .harvest_and_compound(&f.user, &router, &f.path(), &(EXPECTED_REWARD * 2));
+
+        assert_eq!(result.reward_claimed, EXPECTED_REWARD);
+        // Measured, not the `i128::MAX` the router reported.
+        assert_eq!(result.lp_acquired, EXPECTED_REWARD * 2);
+        assert_eq!(result.new_share_balance, STAKE + EXPECTED_REWARD * 2);
+        assert_eq!(
+            f.client.yield_farming_share_balance(&f.user),
+            STAKE + EXPECTED_REWARD * 2,
+            "the swap proceeds must end up staked, not sitting with the user"
+        );
+    }
+
+    #[test]
+    fn compound_leaves_no_tokens_stranded_with_the_user() {
+        let f = setup();
+        let router = f.router(1, 1);
+        f.client
+            .harvest_and_compound(&f.user, &router, &f.path(), &0);
+
+        // Rewards were swapped, LP was re-staked: the caller nets zero of both.
+        assert_eq!(
+            token::Client::new(&f.env, &f.reward_token).balance(&f.user),
+            0
+        );
+        assert_eq!(token::Client::new(&f.env, &f.lp_token).balance(&f.user), 0);
+    }
+
+    #[test]
+    fn compound_emits_event_with_claim_swap_and_stake_amounts() {
+        let f = setup();
+        let router = f.router(1, 1);
+        let result = f
+            .client
+            .harvest_and_compound(&f.user, &router, &f.path(), &0);
+
+        let expected_topics: Vec<Val> = soroban_sdk::vec![
+            &f.env,
+            symbol_short!("hrvcmpnd").into_val(&f.env),
+            f.user.clone().into_val(&f.env),
+        ];
+        let event = f
+            .env
+            .events()
+            .all()
+            .iter()
+            .find(|e| e.0 == f.contract_id && e.1 == expected_topics)
+            .expect("expected an hrvcmpnd event addressed to the caller");
+        let payload = <(i128, i128, i128)>::try_from_val(&f.env, &event.2).unwrap();
+        assert_eq!(
+            payload,
+            (
+                result.reward_claimed,
+                result.lp_acquired,
+                result.new_share_balance
+            )
+        );
+    }
+
+    #[test]
+    fn compounding_raises_the_next_harvests_reward() {
+        let f = setup();
+        let router = f.router(1, 1);
+        f.client
+            .harvest_and_compound(&f.user, &router, &f.path(), &0);
+        let staked_after = f.client.yield_farming_share_balance(&f.user);
+
+        // A second staker splits emissions by share weight, so the compounded
+        // position must now draw the larger slice — the point of the feature.
+        let rival = Address::generate(&f.env);
+        mint(&f.env, &f.lp_token, &rival, STAKE);
+        f.client.stake_lp(&rival, &STAKE);
+        advance_ledgers(&f.env, LEDGERS);
+
+        let user_pending = f.client.pending_yield_rewards(&f.user);
+        let rival_pending = f.client.pending_yield_rewards(&rival);
+        assert!(staked_after > STAKE);
+        assert!(
+            user_pending > rival_pending,
+            "compounded position ({staked_after}) should out-earn the flat one: \
+             user={user_pending} rival={rival_pending}"
+        );
+    }
+
+    // ── Rejections ──────────────────────────────────────────────────────────
+
+    #[test]
+    fn rejects_when_no_rewards_have_accrued() {
+        let f = setup();
+        let router = f.router(1, 1);
+        // Drain the pending balance first so the second call has nothing left.
+        f.client.claim_rewards(&f.user);
+
+        let result = f
+            .client
+            .try_harvest_and_compound(&f.user, &router, &f.path(), &0);
+        assert_eq!(
+            result,
+            Err(Ok(ContractError::HarvestNothingToCompound)),
+            "compounding nothing must fail rather than call the router"
+        );
+    }
+
+    #[test]
+    fn rejects_negative_min_lp_out() {
+        let f = setup();
+        let router = f.router(1, 1);
+        let result = f
+            .client
+            .try_harvest_and_compound(&f.user, &router, &f.path(), &-1);
+        assert_eq!(result, Err(Ok(ContractError::HarvestInvalidMinOut)));
+    }
+
+    #[test]
+    fn rejects_path_not_starting_at_reward_token() {
+        let f = setup();
+        let router = f.router(1, 1);
+        let bogus = Address::generate(&f.env);
+        let path = soroban_sdk::vec![&f.env, bogus, f.lp_token.clone()];
+
+        let result = f
+            .client
+            .try_harvest_and_compound(&f.user, &router, &path, &0);
+        assert_eq!(result, Err(Ok(ContractError::HarvestInvalidPath)));
+    }
+
+    #[test]
+    fn rejects_path_not_ending_at_lp_token() {
+        let f = setup();
+        let router = f.router(1, 1);
+        let bogus = Address::generate(&f.env);
+        let path = soroban_sdk::vec![&f.env, f.reward_token.clone(), bogus];
+
+        let result = f
+            .client
+            .try_harvest_and_compound(&f.user, &router, &path, &0);
+        assert_eq!(result, Err(Ok(ContractError::HarvestInvalidPath)));
+    }
+
+    #[test]
+    fn rejects_single_hop_path() {
+        let f = setup();
+        let router = f.router(1, 1);
+        let path = soroban_sdk::vec![&f.env, f.reward_token.clone()];
+
+        let result = f
+            .client
+            .try_harvest_and_compound(&f.user, &router, &path, &0);
+        assert_eq!(result, Err(Ok(ContractError::HarvestInvalidPath)));
+    }
+
+    #[test]
+    fn rejects_path_longer_than_the_hop_cap() {
+        let f = setup();
+        let router = f.router(1, 1);
+        let mut path = soroban_sdk::vec![&f.env, f.reward_token.clone()];
+        while path.len() < MAX_SWAP_PATH_LEN {
+            path.push_back(Address::generate(&f.env));
+        }
+        path.push_back(f.lp_token.clone());
+        assert_eq!(path.len(), MAX_SWAP_PATH_LEN + 1);
+
+        let result = f
+            .client
+            .try_harvest_and_compound(&f.user, &router, &path, &0);
+        assert_eq!(result, Err(Ok(ContractError::HarvestInvalidPath)));
+    }
+
+    #[test]
+    fn rejects_when_the_router_delivers_nothing() {
+        let f = setup();
+        let router = f.router(0, 1);
+        let result = f
+            .client
+            .try_harvest_and_compound(&f.user, &router, &f.path(), &0);
+        assert_eq!(result, Err(Ok(ContractError::HarvestSwapFailed)));
+    }
+
+    #[test]
+    fn rejects_when_the_router_underdelivers_against_min_lp_out() {
+        let f = setup();
+        // Half the requested output.
+        let router = f.router(1, 2);
+        let result = f
+            .client
+            .try_harvest_and_compound(&f.user, &router, &f.path(), &EXPECTED_REWARD);
+        assert_eq!(result, Err(Ok(ContractError::HarvestSlippageExceeded)));
+    }
+
+    #[test]
+    fn rejects_while_the_vault_is_paused() {
+        let f = setup();
+        let router = f.router(1, 1);
+        f.client.pause_vault(&f.admin);
+
+        let result = f
+            .client
+            .try_harvest_and_compound(&f.user, &router, &f.path(), &0);
+        assert_eq!(result, Err(Ok(ContractError::VaultPaused)));
+    }
+
+    /// The untrusted router is called mid-harvest, so the contract-wide
+    /// reentrancy lock must already be held by then and must refuse a second
+    /// entry.
+    ///
+    /// The lock is taken directly rather than by driving a router that calls
+    /// back in: in this soroban-sdk 20.0.0 native test harness a *sub*
+    /// invocation that returns `Err` escalates to a non-unwinding panic and
+    /// aborts the whole test process, so a live re-entry cannot be observed.
+    /// Holding the lock reproduces the exact state a re-entrant call would
+    /// meet, which is what the guard actually keys off.
+    #[test]
+    fn rejects_entry_while_the_reentrancy_lock_is_held() {
+        let f = setup();
+        let router = f.router(1, 1);
+        f.env.as_contract(&f.contract_id, || {
+            crate::security::reentrancy::lock(&f.env).expect("lock should be free");
+        });
+
+        let result = f
+            .client
+            .try_harvest_and_compound(&f.user, &router, &f.path(), &0);
+        assert_eq!(result, Err(Ok(ContractError::ReentrancyDetected)));
+
+        // Nothing was consumed: the reward is still there to harvest.
+        assert_eq!(f.client.pending_yield_rewards(&f.user), EXPECTED_REWARD);
+    }
+
+    // ── Atomicity ───────────────────────────────────────────────────────────
+
+    #[test]
+    fn failed_swap_leaves_the_reward_claimable() {
+        let f = setup();
+        let router = f.router(0, 1);
+        let lp_before = f.client.yield_farming_share_balance(&f.user);
+
+        assert!(f
+            .client
+            .try_harvest_and_compound(&f.user, &router, &f.path(), &0)
+            .is_err());
+
+        // The whole transaction rolled back, claim included: nothing was burned.
+        assert_eq!(f.client.pending_yield_rewards(&f.user), EXPECTED_REWARD);
+        assert_eq!(f.client.yield_farming_share_balance(&f.user), lp_before);
+        assert_eq!(
+            token::Client::new(&f.env, &f.reward_token).balance(&f.user),
+            0
+        );
+    }
+
+    #[test]
+    fn retry_after_a_failed_route_succeeds() {
+        let f = setup();
+        let dud = f.router(0, 1);
+        assert!(f
+            .client
+            .try_harvest_and_compound(&f.user, &dud, &f.path(), &0)
+            .is_err());
+
+        // Same rewards, better venue.
+        let good = f.router(1, 1);
+        let result = f
+            .client
+            .harvest_and_compound(&f.user, &good, &f.path(), &EXPECTED_REWARD);
+        assert_eq!(result.reward_claimed, EXPECTED_REWARD);
+        assert_eq!(result.lp_acquired, EXPECTED_REWARD);
+    }
+}

--- a/src/vaults/lp_farming.rs
+++ b/src/vaults/lp_farming.rs
@@ -173,8 +173,30 @@ pub fn stake(env: &Env, user: Address, amount: i128) -> Result<i128, ContractErr
     if amount <= 0 {
         return Err(ContractError::InvalidStakeAmount);
     }
-    let config = load_config(env)?;
+    load_config(env)?;
     user.require_auth();
+    stake_preauthorized(env, user, amount)
+}
+
+/// [`stake`] without the `require_auth` call.
+///
+/// Soroban allows only one `require_auth` per address per invocation frame —
+/// a second one aborts the host rather than returning an error. Callers that
+/// have already asserted `user`'s authorization earlier in the same frame
+/// (see [`crate::vaults::harvest_compound::harvest_and_compound`], where
+/// [`claim_rewards`] does it) must use this entry point instead of [`stake`].
+///
+/// Not exported as a contract entry point: reaching it always requires having
+/// authorized `user` first.
+pub(crate) fn stake_preauthorized(
+    env: &Env,
+    user: Address,
+    amount: i128,
+) -> Result<i128, ContractError> {
+    if amount <= 0 {
+        return Err(ContractError::InvalidStakeAmount);
+    }
+    let config = load_config(env)?;
     let acc_reward_per_share = update_pool(env, &config)?;
     settle_user(env, &user, acc_reward_per_share)?;
     token::Client::new(env, &config.lp_token).transfer(
@@ -183,7 +205,22 @@ pub fn stake(env: &Env, user: Address, amount: i128) -> Result<i128, ContractErr
         &amount,
     );
     let shares = read_i128(env, &FarmingStorageKey::Shares(user.clone()));
-    write_i128(env, &FarmingStorageKey::Shares(user.clone()), shares.checked_add(amount).ok_or(ContractError::MathOverflow)?);
+    let new_shares = shares.checked_add(amount).ok_or(ContractError::MathOverflow)?;
+    write_i128(env, &FarmingStorageKey::Shares(user.clone()), new_shares);
+    // Re-baseline the reward debt against the *post-stake* share count.
+    // `settle_user` above set it from the old count, so without this the newly
+    // staked `amount` carries zero debt and the next settle credits it with
+    // `amount * acc_reward_per_share / REWARD_PRECISION` — the pool's entire
+    // accrued history, paid out on a stake that has earned nothing yet.
+    write_i128(
+        env,
+        &FarmingStorageKey::RewardDebt(user.clone()),
+        new_shares
+            .checked_mul(acc_reward_per_share)
+            .ok_or(ContractError::MathOverflow)?
+            .checked_div(REWARD_PRECISION)
+            .ok_or(ContractError::DivisionByZero)?,
+    );
     env.storage().instance().set(
         &FarmingStorageKey::TotalShares,
         &total_shares(env).checked_add(amount).ok_or(ContractError::MathOverflow)?,
@@ -227,7 +264,7 @@ pub fn exit(env: &Env, user: Address) -> Result<(i128, i128), ContractError> {
         write_i128(env, &FarmingStorageKey::Shares(user.clone()), 0);
         write_i128(
             env,
-            &FarmingStorageKey::RewardDebt(user),
+            &FarmingStorageKey::RewardDebt(user.clone()),
             0,
         );
         env.storage().instance().set(
@@ -283,4 +320,141 @@ pub fn pending_rewards(env: &Env, user: Address) -> Result<i128, ContractError> 
     Ok(read_i128(env, &FarmingStorageKey::AccruedRewards(user)).checked_add(
         accrued.checked_sub(reward_debt).ok_or(ContractError::MathOverflow)?,
     ).ok_or(ContractError::MathOverflow)?)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use soroban_sdk::testutils::{Address as _, Ledger};
+
+    const STAKE: i128 = 1_000_000;
+    const EMISSION: i128 = 100;
+    const LEDGERS: u32 = 10;
+
+    struct Farm {
+        env: Env,
+        client: crate::TimeLockedUpgradeContractClient<'static>,
+        lp_token: Address,
+    }
+
+    fn mint(env: &Env, asset: &Address, to: &Address, amount: i128) {
+        token::StellarAssetClient::new(env, asset).mint(to, &amount);
+    }
+
+    /// Editing the live `LedgerInfo` rather than building a fresh one keeps the
+    /// entry-TTL policy that the registered Stellar-asset contracts were
+    /// written under; resetting those fields makes later token calls fail with
+    /// `Error(Context, InternalError)` on soroban-sdk 20.0.0.
+    fn advance_ledgers(env: &Env, count: u32) {
+        let mut info = env.ledger().get();
+        info.sequence_number += count;
+        info.timestamp += 5 * count as u64;
+        env.ledger().set(info);
+    }
+
+    fn setup() -> Farm {
+        let env = Env::default();
+        env.mock_all_auths();
+        let contract_id = env.register_contract(None, crate::TimeLockedUpgradeContract);
+        let client = crate::TimeLockedUpgradeContractClient::new(&env, &contract_id);
+
+        let admin = Address::generate(&env);
+        let treasury = Address::generate(&env);
+        client.initialize(&admin, &treasury);
+
+        let issuer = Address::generate(&env);
+        let lp_token = env.register_stellar_asset_contract(issuer.clone());
+        let reward_token = env.register_stellar_asset_contract(issuer);
+        client.init_yield_farming(&admin, &lp_token, &reward_token, &EMISSION);
+
+        let funder = Address::generate(&env);
+        mint(&env, &reward_token, &funder, 1_000_000);
+        client.fund_yield_rewards(&funder, &1_000_000);
+
+        Farm {
+            env,
+            client,
+            lp_token,
+        }
+    }
+
+    fn new_staker(f: &Farm, amount: i128) -> Address {
+        let who = Address::generate(&f.env);
+        mint(&f.env, &f.lp_token, &who, amount);
+        f.client.stake_lp(&who, &amount);
+        who
+    }
+
+    /// Regression test: `stake` used to leave `RewardDebt` at the pre-stake
+    /// share count, so a staker entering a pool that had already accrued
+    /// `acc_reward_per_share` was immediately credited
+    /// `amount * acc / REWARD_PRECISION` — the pool's whole history — and could
+    /// drain the reward pot by staking and claiming in one ledger.
+    #[test]
+    fn staking_into_a_mature_pool_earns_nothing_for_earlier_ledgers() {
+        let f = setup();
+        let alice = new_staker(&f, STAKE);
+        advance_ledgers(&f.env, LEDGERS);
+        assert_eq!(
+            f.client.pending_yield_rewards(&alice),
+            EMISSION * LEDGERS as i128,
+            "the sole staker should hold every emission so far"
+        );
+
+        // Bob joins now and claims in the same ledger: zero time in the pool.
+        let bob = new_staker(&f, STAKE);
+        assert_eq!(
+            f.client.pending_yield_rewards(&bob),
+            0,
+            "a staker with zero ledgers in the pool is owed zero"
+        );
+        assert_eq!(f.client.claim_rewards(&bob), 0);
+
+        // Alice's entitlement is untouched by Bob's arrival.
+        assert_eq!(
+            f.client.pending_yield_rewards(&alice),
+            EMISSION * LEDGERS as i128
+        );
+    }
+
+    #[test]
+    fn emissions_split_by_share_weight_after_a_second_staker_joins() {
+        let f = setup();
+        let alice = new_staker(&f, STAKE);
+        advance_ledgers(&f.env, LEDGERS);
+        let bob = new_staker(&f, STAKE);
+
+        let alice_before = f.client.pending_yield_rewards(&alice);
+        advance_ledgers(&f.env, LEDGERS);
+
+        // Equal stakes, so the emissions of the second window split evenly.
+        let window = EMISSION * LEDGERS as i128;
+        assert_eq!(
+            f.client.pending_yield_rewards(&bob),
+            window / 2,
+            "bob earns only his half of the window he was present for"
+        );
+        assert_eq!(
+            f.client.pending_yield_rewards(&alice) - alice_before,
+            window / 2
+        );
+    }
+
+    #[test]
+    fn topping_up_a_stake_does_not_mint_phantom_rewards() {
+        let f = setup();
+        let alice = new_staker(&f, STAKE);
+        advance_ledgers(&f.env, LEDGERS);
+
+        let before = f.client.pending_yield_rewards(&alice);
+        mint(&f.env, &f.lp_token, &alice, STAKE);
+        f.client.stake_lp(&alice, &STAKE);
+
+        assert_eq!(
+            f.client.pending_yield_rewards(&alice),
+            before,
+            "doubling the stake must not retroactively pay on the new half"
+        );
+        assert_eq!(f.client.yield_farming_share_balance(&alice), STAKE * 2);
+    }
 }

--- a/src/vaults/mod.rs
+++ b/src/vaults/mod.rs
@@ -2,3 +2,4 @@ pub mod liquidation;
 pub mod lp_farming;
 pub mod pause_guard;
 pub mod autocompound;
+pub mod harvest_compound;

--- a/src/vaults/pause_guard.rs
+++ b/src/vaults/pause_guard.rs
@@ -166,9 +166,9 @@ mod tests {
     use super::*;
     use soroban_sdk::testutils::Address as _;
     use soroban_sdk::testutils::Events;
-    use soroban_sdk::Env;
+    use soroban_sdk::{Env, IntoVal};
 
-    fn setup() -> (Env, Address, Address) {
+    fn setup() -> (Env, Address, Address, Address) {
         let env = Env::default();
         env.mock_all_auths();
         let admin = Address::generate(&env);
@@ -208,10 +208,16 @@ mod tests {
     #[test]
     fn admin_can_unpause_vault() {
         let (env, contract_id, admin, _) = setup();
+        // One `as_contract` per auth-requiring call: Soroban allows a single
+        // `require_auth` per address per invocation frame, so pausing and
+        // unpausing inside one frame fails with `Auth, ExistingValue` rather
+        // than exercising the guard. Separate frames model the two separate
+        // transactions this really is.
         env.as_contract(&contract_id, || {
             pause_vault(&env, &admin).unwrap();
             assert!(is_vault_paused(&env));
-
+        });
+        env.as_contract(&contract_id, || {
             unpause_vault(&env, &admin).expect("admin should be able to unpause vault");
             assert!(!is_vault_paused(&env));
         });
@@ -274,9 +280,11 @@ mod tests {
     #[test]
     fn emergency_withdraw_clears_flag_on_success() {
         let (env, contract_id, admin, _) = setup();
+        // Separate frames: one `require_auth` per address per invocation.
         env.as_contract(&contract_id, || {
             pause_vault(&env, &admin).unwrap();
-
+        });
+        env.as_contract(&contract_id, || {
             let asset = Symbol::new(&env, "USDC");
             let _ = emergency_vault_withdraw(
                 &env,
@@ -293,9 +301,11 @@ mod tests {
     #[test]
     fn emergency_withdraw_clears_flag_on_failure() {
         let (env, contract_id, admin, _) = setup();
+        // Separate frames: one `require_auth` per address per invocation.
         env.as_contract(&contract_id, || {
             pause_vault(&env, &admin).unwrap();
-
+        });
+        env.as_contract(&contract_id, || {
             let asset = Symbol::new(&env, "USDC");
             let result = emergency_vault_withdraw(
                 &env,
@@ -313,9 +323,11 @@ mod tests {
     #[test]
     fn emergency_withdraw_emits_event() {
         let (env, contract_id, admin, _) = setup();
+        // Separate frames: one `require_auth` per address per invocation.
         env.as_contract(&contract_id, || {
             pause_vault(&env, &admin).unwrap();
-
+        });
+        env.as_contract(&contract_id, || {
             let asset = Symbol::new(&env, "USDC");
             let _ = emergency_vault_withdraw(
                 &env,
@@ -327,8 +339,8 @@ mod tests {
 
             let events = env.events().all();
             let found = events.iter().any(|e| {
-                e.0 == (contract_id.clone(),)
-                    && e.1 == (Symbol::new(&env, "VAULT_EMERG_WD"),)
+                e.0 == contract_id
+                    && e.1 == soroban_sdk::vec![&env, Symbol::new(&env, "VAULT_EMERG_WD").into_val(&env)]
             });
             assert!(found, "should emit VAULT_EMERG_WD event");
         });
@@ -342,8 +354,8 @@ mod tests {
 
             let events = env.events().all();
             let found = events.iter().any(|e| {
-                e.0 == (contract_id.clone(),)
-                    && e.1 == (Symbol::new(&env, "VAULT_PAUSE"),)
+                e.0 == contract_id
+                    && e.1 == soroban_sdk::vec![&env, Symbol::new(&env, "VAULT_PAUSE").into_val(&env)]
             });
             assert!(found, "should emit VAULT_PAUSE event");
         });
@@ -352,14 +364,17 @@ mod tests {
     #[test]
     fn unpause_emits_event() {
         let (env, contract_id, admin, _) = setup();
+        // Separate frames: one `require_auth` per address per invocation.
         env.as_contract(&contract_id, || {
             pause_vault(&env, &admin).unwrap();
+        });
+        env.as_contract(&contract_id, || {
             unpause_vault(&env, &admin).unwrap();
 
             let events = env.events().all();
             let found = events.iter().any(|e| {
-                e.0 == (contract_id.clone(),)
-                    && e.1 == (Symbol::new(&env, "VAULT_UNPAUSE"),)
+                e.0 == contract_id
+                    && e.1 == soroban_sdk::vec![&env, Symbol::new(&env, "VAULT_UNPAUSE").into_val(&env)]
             });
             assert!(found, "should emit VAULT_UNPAUSE event");
         });

--- a/test_snapshots/config/tests/set_and_get_round_trips_full_struct.1.json
+++ b/test_snapshots/config/tests/set_and_get_round_trips_full_struct.1.json
@@ -132,6 +132,14 @@
                             },
                             {
                               "key": {
+                                "symbol": "max_fee_ceiling"
+                              },
+                              "val": {
+                                "u64": 10000
+                              }
+                            },
+                            {
+                              "key": {
                                 "symbol": "value"
                               },
                               "val": {
@@ -188,6 +196,18 @@
                         },
                         "val": {
                           "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "SchemaVersion"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "u32": 2
                         }
                       }
                     ]

--- a/test_snapshots/config/tests/set_rejects_invalid_config.1.json
+++ b/test_snapshots/config/tests/set_rejects_invalid_config.1.json
@@ -77,6 +77,14 @@
                             },
                             {
                               "key": {
+                                "symbol": "max_fee_ceiling"
+                              },
+                              "val": {
+                                "u64": 10000
+                              }
+                            },
+                            {
+                              "key": {
                                 "symbol": "value"
                               },
                               "val": {
@@ -92,6 +100,18 @@
                         },
                         "val": {
                           "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "SchemaVersion"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "u32": 2
                         }
                       }
                     ]
@@ -330,7 +350,7 @@
             ],
             "data": {
               "error": {
-                "contract": 29
+                "contract": 28
               }
             }
           }
@@ -351,7 +371,7 @@
               },
               {
                 "error": {
-                  "contract": 29
+                  "contract": 28
                 }
               }
             ],
@@ -376,7 +396,7 @@
               },
               {
                 "error": {
-                  "contract": 29
+                  "contract": 28
                 }
               }
             ],

--- a/test_snapshots/config/tests/set_rejects_non_admin_caller.1.json
+++ b/test_snapshots/config/tests/set_rejects_non_admin_caller.1.json
@@ -77,6 +77,14 @@
                             },
                             {
                               "key": {
+                                "symbol": "max_fee_ceiling"
+                              },
+                              "val": {
+                                "u64": 10000
+                              }
+                            },
+                            {
+                              "key": {
                                 "symbol": "value"
                               },
                               "val": {
@@ -92,6 +100,18 @@
                         },
                         "val": {
                           "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM"
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "SchemaVersion"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "u32": 2
                         }
                       }
                     ]

--- a/test_snapshots/fees/tests/corridor_weight_profile_is_isolated_from_fee_pool.1.json
+++ b/test_snapshots/fees/tests/corridor_weight_profile_is_isolated_from_fee_pool.1.json
@@ -26,63 +26,6 @@
         }
       ]
     ],
-    [
-      [
-        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
-        {
-          "function": {
-            "contract_fn": {
-              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
-              "function_name": "add_corridor_fees",
-              "args": [
-                {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
-                },
-                {
-                  "u32": 3897123275
-                },
-                {
-                  "u64": 1000
-                },
-                {
-                  "u64": 25
-                }
-              ]
-            }
-          },
-          "sub_invocations": []
-        }
-      ]
-    ],
-    [
-      [
-        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
-        {
-          "function": {
-            "contract_fn": {
-              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
-              "function_name": "set_corridor_weight",
-              "args": [
-                {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
-                },
-                {
-                  "u32": 3897123275
-                },
-                {
-                  "u64": 70
-                },
-                {
-                  "u64": 30
-                }
-              ]
-            }
-          },
-          "sub_invocations": []
-        }
-      ]
-    ],
-    [],
     []
   ],
   "ledger": {
@@ -95,76 +38,6 @@
     "min_temp_entry_ttl": 16,
     "max_entry_ttl": 6312000,
     "ledger_entries": [
-      [
-        {
-          "contract_data": {
-            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
-            "key": {
-              "vec": [
-                {
-                  "symbol": "Profile"
-                },
-                {
-                  "u32": 3897123275
-                }
-              ]
-            },
-            "durability": "persistent"
-          }
-        },
-        [
-          {
-            "last_modified_ledger_seq": 0,
-            "data": {
-              "contract_data": {
-                "ext": "v0",
-                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
-                "key": {
-                  "vec": [
-                    {
-                      "symbol": "Profile"
-                    },
-                    {
-                      "u32": 3897123275
-                    }
-                  ]
-                },
-                "durability": "persistent",
-                "val": {
-                  "map": [
-                    {
-                      "key": {
-                        "symbol": "asset"
-                      },
-                      "val": {
-                        "u32": 3897123275
-                      }
-                    },
-                    {
-                      "key": {
-                        "symbol": "base_weight"
-                      },
-                      "val": {
-                        "u64": 70
-                      }
-                    },
-                    {
-                      "key": {
-                        "symbol": "dynamic_weight"
-                      },
-                      "val": {
-                        "u64": 30
-                      }
-                    }
-                  ]
-                }
-              }
-            },
-            "ext": "v0"
-          },
-          4095
-        ]
-      ],
       [
         {
           "contract_data": {
@@ -204,6 +77,14 @@
                             },
                             {
                               "key": {
+                                "symbol": "max_fee_ceiling"
+                              },
+                              "val": {
+                                "u64": 10000
+                              }
+                            },
+                            {
+                              "key": {
                                 "symbol": "value"
                               },
                               "val": {
@@ -225,40 +106,12 @@
                         "key": {
                           "vec": [
                             {
-                              "symbol": "CorridorPool"
-                            },
-                            {
-                              "u32": 3897123275
+                              "symbol": "SchemaVersion"
                             }
                           ]
                         },
                         "val": {
-                          "map": [
-                            {
-                              "key": {
-                                "symbol": "asset"
-                              },
-                              "val": {
-                                "u32": 3897123275
-                              }
-                            },
-                            {
-                              "key": {
-                                "symbol": "collected"
-                              },
-                              "val": {
-                                "u64": 1000
-                              }
-                            },
-                            {
-                              "key": {
-                                "symbol": "variable_pool"
-                              },
-                              "val": {
-                                "u64": 25
-                              }
-                            }
-                          ]
+                          "u32": 2
                         }
                       }
                     ]
@@ -268,7 +121,7 @@
             },
             "ext": "v0"
           },
-          105000
+          4095
         ]
       ],
       [
@@ -306,72 +159,6 @@
       ],
       [
         {
-          "contract_data": {
-            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
-            "key": {
-              "ledger_key_nonce": {
-                "nonce": 1033654523790656264
-              }
-            },
-            "durability": "temporary"
-          }
-        },
-        [
-          {
-            "last_modified_ledger_seq": 0,
-            "data": {
-              "contract_data": {
-                "ext": "v0",
-                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
-                "key": {
-                  "ledger_key_nonce": {
-                    "nonce": 1033654523790656264
-                  }
-                },
-                "durability": "temporary",
-                "val": "void"
-              }
-            },
-            "ext": "v0"
-          },
-          15
-        ]
-      ],
-      [
-        {
-          "contract_data": {
-            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
-            "key": {
-              "ledger_key_nonce": {
-                "nonce": 5541220902715666415
-              }
-            },
-            "durability": "temporary"
-          }
-        },
-        [
-          {
-            "last_modified_ledger_seq": 0,
-            "data": {
-              "contract_data": {
-                "ext": "v0",
-                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
-                "key": {
-                  "ledger_key_nonce": {
-                    "nonce": 5541220902715666415
-                  }
-                },
-                "durability": "temporary",
-                "val": "void"
-              }
-            },
-            "ext": "v0"
-          },
-          15
-        ]
-      ],
-      [
-        {
           "contract_code": {
             "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
           }
@@ -388,7 +175,7 @@
             },
             "ext": "v0"
           },
-          105000
+          4095
         ]
       ]
     ]
@@ -503,37 +290,39 @@
               }
             ],
             "data": {
-              "map": [
-                {
-                  "key": {
-                    "symbol": "asset"
-                  },
-                  "val": {
-                    "u32": 3897123275
-                  }
-                },
-                {
-                  "key": {
-                    "symbol": "collected"
-                  },
-                  "val": {
-                    "u64": 1000
-                  }
-                },
-                {
-                  "key": {
-                    "symbol": "variable_pool"
-                  },
-                  "val": {
-                    "u64": 25
-                  }
-                }
-              ]
+              "error": {
+                "contract": 48
+              }
             }
           }
         }
       },
-      "failed_call": false
+      "failed_call": true
+    },
+    {
+      "event": {
+        "ext": "v0",
+        "contract_id": "0000000000000000000000000000000000000000000000000000000000000001",
+        "type_": "diagnostic",
+        "body": {
+          "v0": {
+            "topics": [
+              {
+                "symbol": "error"
+              },
+              {
+                "error": {
+                  "contract": 48
+                }
+              }
+            ],
+            "data": {
+              "string": "escalating Ok(ScErrorType::Contract) frame-exit to Err"
+            }
+          }
+        }
+      },
+      "failed_call": true
     },
     {
       "event": {
@@ -544,76 +333,37 @@
           "v0": {
             "topics": [
               {
-                "symbol": "fn_call"
+                "symbol": "error"
               },
               {
-                "bytes": "0000000000000000000000000000000000000000000000000000000000000001"
-              },
-              {
-                "symbol": "set_corridor_weight"
+                "error": {
+                  "contract": 48
+                }
               }
             ],
             "data": {
               "vec": [
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                  "string": "contract call failed"
                 },
                 {
-                  "u32": 3897123275
+                  "symbol": "add_corridor_fees"
                 },
                 {
-                  "u64": 70
-                },
-                {
-                  "u64": 30
-                }
-              ]
-            }
-          }
-        }
-      },
-      "failed_call": false
-    },
-    {
-      "event": {
-        "ext": "v0",
-        "contract_id": "0000000000000000000000000000000000000000000000000000000000000001",
-        "type_": "diagnostic",
-        "body": {
-          "v0": {
-            "topics": [
-              {
-                "symbol": "fn_return"
-              },
-              {
-                "symbol": "set_corridor_weight"
-              }
-            ],
-            "data": {
-              "map": [
-                {
-                  "key": {
-                    "symbol": "asset"
-                  },
-                  "val": {
-                    "u32": 3897123275
-                  }
-                },
-                {
-                  "key": {
-                    "symbol": "base_weight"
-                  },
-                  "val": {
-                    "u64": 70
-                  }
-                },
-                {
-                  "key": {
-                    "symbol": "dynamic_weight"
-                  },
-                  "val": {
-                    "u64": 30
-                  }
+                  "vec": [
+                    {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                    },
+                    {
+                      "u32": 3897123275
+                    },
+                    {
+                      "u64": 1000
+                    },
+                    {
+                      "u64": 25
+                    }
+                  ]
                 }
               ]
             }
@@ -631,139 +381,16 @@
           "v0": {
             "topics": [
               {
-                "symbol": "fn_call"
+                "symbol": "error"
               },
               {
-                "bytes": "0000000000000000000000000000000000000000000000000000000000000001"
-              },
-              {
-                "symbol": "get_corridor_fee_pool"
-              }
-            ],
-            "data": {
-              "u32": 3897123275
-            }
-          }
-        }
-      },
-      "failed_call": false
-    },
-    {
-      "event": {
-        "ext": "v0",
-        "contract_id": "0000000000000000000000000000000000000000000000000000000000000001",
-        "type_": "diagnostic",
-        "body": {
-          "v0": {
-            "topics": [
-              {
-                "symbol": "fn_return"
-              },
-              {
-                "symbol": "get_corridor_fee_pool"
-              }
-            ],
-            "data": {
-              "map": [
-                {
-                  "key": {
-                    "symbol": "asset"
-                  },
-                  "val": {
-                    "u32": 3897123275
-                  }
-                },
-                {
-                  "key": {
-                    "symbol": "collected"
-                  },
-                  "val": {
-                    "u64": 1000
-                  }
-                },
-                {
-                  "key": {
-                    "symbol": "variable_pool"
-                  },
-                  "val": {
-                    "u64": 25
-                  }
+                "error": {
+                  "contract": 48
                 }
-              ]
-            }
-          }
-        }
-      },
-      "failed_call": false
-    },
-    {
-      "event": {
-        "ext": "v0",
-        "contract_id": null,
-        "type_": "diagnostic",
-        "body": {
-          "v0": {
-            "topics": [
-              {
-                "symbol": "fn_call"
-              },
-              {
-                "bytes": "0000000000000000000000000000000000000000000000000000000000000001"
-              },
-              {
-                "symbol": "get_corridor_weight"
               }
             ],
             "data": {
-              "u32": 3897123275
-            }
-          }
-        }
-      },
-      "failed_call": false
-    },
-    {
-      "event": {
-        "ext": "v0",
-        "contract_id": "0000000000000000000000000000000000000000000000000000000000000001",
-        "type_": "diagnostic",
-        "body": {
-          "v0": {
-            "topics": [
-              {
-                "symbol": "fn_return"
-              },
-              {
-                "symbol": "get_corridor_weight"
-              }
-            ],
-            "data": {
-              "map": [
-                {
-                  "key": {
-                    "symbol": "asset"
-                  },
-                  "val": {
-                    "u32": 3897123275
-                  }
-                },
-                {
-                  "key": {
-                    "symbol": "base_weight"
-                  },
-                  "val": {
-                    "u64": 70
-                  }
-                },
-                {
-                  "key": {
-                    "symbol": "dynamic_weight"
-                  },
-                  "val": {
-                    "u64": 30
-                  }
-                }
-              ]
+              "string": "escalating error to panic"
             }
           }
         }

--- a/test_snapshots/fees/tests/non_admin_cannot_edit_corridor_weight_profile.1.json
+++ b/test_snapshots/fees/tests/non_admin_cannot_edit_corridor_weight_profile.1.json
@@ -77,6 +77,14 @@
                             },
                             {
                               "key": {
+                                "symbol": "max_fee_ceiling"
+                              },
+                              "val": {
+                                "u64": 10000
+                              }
+                            },
+                            {
+                              "key": {
                                 "symbol": "value"
                               },
                               "val": {
@@ -92,6 +100,18 @@
                         },
                         "val": {
                           "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "SchemaVersion"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "u32": 2
                         }
                       }
                     ]

--- a/test_snapshots/query_guardrail_tests/test_get_data_before_and_after_init.1.json
+++ b/test_snapshots/query_guardrail_tests/test_get_data_before_and_after_init.1.json
@@ -78,6 +78,14 @@
                             },
                             {
                               "key": {
+                                "symbol": "max_fee_ceiling"
+                              },
+                              "val": {
+                                "u64": 10000
+                              }
+                            },
+                            {
+                              "key": {
                                 "symbol": "value"
                               },
                               "val": {
@@ -93,6 +101,18 @@
                         },
                         "val": {
                           "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "SchemaVersion"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "u32": 2
                         }
                       }
                     ]
@@ -372,6 +392,14 @@
                   },
                   "val": {
                     "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                  }
+                },
+                {
+                  "key": {
+                    "symbol": "max_fee_ceiling"
+                  },
+                  "val": {
+                    "u64": 10000
                   }
                 },
                 {

--- a/test_snapshots/query_guardrail_tests/test_get_data_is_idempotent.1.json
+++ b/test_snapshots/query_guardrail_tests/test_get_data_is_idempotent.1.json
@@ -27,8 +27,6 @@
       ]
     ],
     [],
-    [],
-    [],
     []
   ],
   "ledger": {
@@ -80,6 +78,14 @@
                             },
                             {
                               "key": {
+                                "symbol": "max_fee_ceiling"
+                              },
+                              "val": {
+                                "u64": 10000
+                              }
+                            },
+                            {
+                              "key": {
                                 "symbol": "value"
                               },
                               "val": {
@@ -95,6 +101,18 @@
                         },
                         "val": {
                           "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "SchemaVersion"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "u32": 2
                         }
                       }
                     ]
@@ -269,66 +287,10 @@
                 },
                 {
                   "key": {
-                    "symbol": "value"
+                    "symbol": "max_fee_ceiling"
                   },
                   "val": {
-                    "u64": 0
-                  }
-                }
-              ]
-            }
-          }
-        }
-      },
-      "failed_call": false
-    },
-    {
-      "event": {
-        "ext": "v0",
-        "contract_id": null,
-        "type_": "diagnostic",
-        "body": {
-          "v0": {
-            "topics": [
-              {
-                "symbol": "fn_call"
-              },
-              {
-                "bytes": "0000000000000000000000000000000000000000000000000000000000000001"
-              },
-              {
-                "symbol": "get_data"
-              }
-            ],
-            "data": "void"
-          }
-        }
-      },
-      "failed_call": false
-    },
-    {
-      "event": {
-        "ext": "v0",
-        "contract_id": "0000000000000000000000000000000000000000000000000000000000000001",
-        "type_": "diagnostic",
-        "body": {
-          "v0": {
-            "topics": [
-              {
-                "symbol": "fn_return"
-              },
-              {
-                "symbol": "get_data"
-              }
-            ],
-            "data": {
-              "map": [
-                {
-                  "key": {
-                    "symbol": "admin"
-                  },
-                  "val": {
-                    "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                    "u64": 10000
                   }
                 },
                 {
@@ -397,66 +359,10 @@
                 },
                 {
                   "key": {
-                    "symbol": "value"
+                    "symbol": "max_fee_ceiling"
                   },
                   "val": {
-                    "u64": 0
-                  }
-                }
-              ]
-            }
-          }
-        }
-      },
-      "failed_call": false
-    },
-    {
-      "event": {
-        "ext": "v0",
-        "contract_id": null,
-        "type_": "diagnostic",
-        "body": {
-          "v0": {
-            "topics": [
-              {
-                "symbol": "fn_call"
-              },
-              {
-                "bytes": "0000000000000000000000000000000000000000000000000000000000000001"
-              },
-              {
-                "symbol": "get_data"
-              }
-            ],
-            "data": "void"
-          }
-        }
-      },
-      "failed_call": false
-    },
-    {
-      "event": {
-        "ext": "v0",
-        "contract_id": "0000000000000000000000000000000000000000000000000000000000000001",
-        "type_": "diagnostic",
-        "body": {
-          "v0": {
-            "topics": [
-              {
-                "symbol": "fn_return"
-              },
-              {
-                "symbol": "get_data"
-              }
-            ],
-            "data": {
-              "map": [
-                {
-                  "key": {
-                    "symbol": "admin"
-                  },
-                  "val": {
-                    "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                    "u64": 10000
                   }
                 },
                 {

--- a/test_snapshots/query_guardrail_tests/test_is_data_fresh_does_not_mutate_heartbeat.1.json
+++ b/test_snapshots/query_guardrail_tests/test_is_data_fresh_does_not_mutate_heartbeat.1.json
@@ -98,7 +98,11 @@
           "contract_data": {
             "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
             "key": {
-              "symbol": "HBEAT"
+              "vec": [
+                {
+                  "u32": 2699528942
+                }
+              ]
             },
             "durability": "temporary"
           }
@@ -111,20 +115,15 @@
                 "ext": "v0",
                 "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
                 "key": {
-                  "symbol": "HBEAT"
+                  "vec": [
+                    {
+                      "u32": 2699528942
+                    }
+                  ]
                 },
                 "durability": "temporary",
                 "val": {
-                  "map": [
-                    {
-                      "key": {
-                        "u32": 2699528942
-                      },
-                      "val": {
-                        "u64": 0
-                      }
-                    }
-                  ]
+                  "u64": 0
                 }
               }
             },
@@ -172,6 +171,14 @@
                             },
                             {
                               "key": {
+                                "symbol": "max_fee_ceiling"
+                              },
+                              "val": {
+                                "u64": 10000
+                              }
+                            },
+                            {
+                              "key": {
                                 "symbol": "value"
                               },
                               "val": {
@@ -179,6 +186,14 @@
                               }
                             }
                           ]
+                        }
+                      },
+                      {
+                        "key": {
+                          "symbol": "LASTACT"
+                        },
+                        "val": {
+                          "u64": 0
                         }
                       },
                       {
@@ -228,6 +243,18 @@
                             }
                           ]
                         }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "SchemaVersion"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "u32": 2
+                        }
                       }
                     ]
                   }
@@ -236,7 +263,7 @@
             },
             "ext": "v0"
           },
-          105000
+          535680
         ]
       ],
       [
@@ -356,7 +383,7 @@
             },
             "ext": "v0"
           },
-          105000
+          535680
         ]
       ]
     ]

--- a/test_snapshots/query_guardrail_tests/test_is_data_fresh_transitions_on_staleness.1.json
+++ b/test_snapshots/query_guardrail_tests/test_is_data_fresh_transitions_on_staleness.1.json
@@ -94,7 +94,11 @@
           "contract_data": {
             "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
             "key": {
-              "symbol": "HBEAT"
+              "vec": [
+                {
+                  "u32": 3418146798
+                }
+              ]
             },
             "durability": "temporary"
           }
@@ -107,20 +111,15 @@
                 "ext": "v0",
                 "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
                 "key": {
-                  "symbol": "HBEAT"
+                  "vec": [
+                    {
+                      "u32": 3418146798
+                    }
+                  ]
                 },
                 "durability": "temporary",
                 "val": {
-                  "map": [
-                    {
-                      "key": {
-                        "u32": 3418146798
-                      },
-                      "val": {
-                        "u64": 0
-                      }
-                    }
-                  ]
+                  "u64": 0
                 }
               }
             },
@@ -168,6 +167,14 @@
                             },
                             {
                               "key": {
+                                "symbol": "max_fee_ceiling"
+                              },
+                              "val": {
+                                "u64": 10000
+                              }
+                            },
+                            {
+                              "key": {
                                 "symbol": "value"
                               },
                               "val": {
@@ -175,6 +182,14 @@
                               }
                             }
                           ]
+                        }
+                      },
+                      {
+                        "key": {
+                          "symbol": "LASTACT"
+                        },
+                        "val": {
+                          "u64": 0
                         }
                       },
                       {
@@ -224,6 +239,18 @@
                             }
                           ]
                         }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "SchemaVersion"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "u32": 2
+                        }
                       }
                     ]
                   }
@@ -232,7 +259,7 @@
             },
             "ext": "v0"
           },
-          105000
+          535680
         ]
       ],
       [
@@ -352,7 +379,7 @@
             },
             "ext": "v0"
           },
-          105000
+          535680
         ]
       ]
     ]

--- a/test_snapshots/query_guardrail_tests/test_is_data_fresh_unknown_asset_returns_false.1.json
+++ b/test_snapshots/query_guardrail_tests/test_is_data_fresh_unknown_asset_returns_false.1.json
@@ -77,6 +77,14 @@
                             },
                             {
                               "key": {
+                                "symbol": "max_fee_ceiling"
+                              },
+                              "val": {
+                                "u64": 10000
+                              }
+                            },
+                            {
+                              "key": {
                                 "symbol": "value"
                               },
                               "val": {
@@ -92,6 +100,18 @@
                         },
                         "val": {
                           "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "SchemaVersion"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "u32": 2
                         }
                       }
                     ]

--- a/test_snapshots/query_guardrail_tests/test_query_methods_do_not_interfere.1.json
+++ b/test_snapshots/query_guardrail_tests/test_query_methods_do_not_interfere.1.json
@@ -28,8 +28,6 @@
     ],
     [],
     [],
-    [],
-    [],
     []
   ],
   "ledger": {
@@ -81,6 +79,14 @@
                             },
                             {
                               "key": {
+                                "symbol": "max_fee_ceiling"
+                              },
+                              "val": {
+                                "u64": 10000
+                              }
+                            },
+                            {
+                              "key": {
                                 "symbol": "value"
                               },
                               "val": {
@@ -96,6 +102,18 @@
                         },
                         "val": {
                           "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "SchemaVersion"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "u32": 2
                         }
                       }
                     ]
@@ -270,66 +288,10 @@
                 },
                 {
                   "key": {
-                    "symbol": "value"
+                    "symbol": "max_fee_ceiling"
                   },
                   "val": {
-                    "u64": 0
-                  }
-                }
-              ]
-            }
-          }
-        }
-      },
-      "failed_call": false
-    },
-    {
-      "event": {
-        "ext": "v0",
-        "contract_id": null,
-        "type_": "diagnostic",
-        "body": {
-          "v0": {
-            "topics": [
-              {
-                "symbol": "fn_call"
-              },
-              {
-                "bytes": "0000000000000000000000000000000000000000000000000000000000000001"
-              },
-              {
-                "symbol": "get_data"
-              }
-            ],
-            "data": "void"
-          }
-        }
-      },
-      "failed_call": false
-    },
-    {
-      "event": {
-        "ext": "v0",
-        "contract_id": "0000000000000000000000000000000000000000000000000000000000000001",
-        "type_": "diagnostic",
-        "body": {
-          "v0": {
-            "topics": [
-              {
-                "symbol": "fn_return"
-              },
-              {
-                "symbol": "get_data"
-              }
-            ],
-            "data": {
-              "map": [
-                {
-                  "key": {
-                    "symbol": "admin"
-                  },
-                  "val": {
-                    "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                    "u64": 10000
                   }
                 },
                 {
@@ -447,66 +409,10 @@
                 },
                 {
                   "key": {
-                    "symbol": "value"
+                    "symbol": "max_fee_ceiling"
                   },
                   "val": {
-                    "u64": 0
-                  }
-                }
-              ]
-            }
-          }
-        }
-      },
-      "failed_call": false
-    },
-    {
-      "event": {
-        "ext": "v0",
-        "contract_id": null,
-        "type_": "diagnostic",
-        "body": {
-          "v0": {
-            "topics": [
-              {
-                "symbol": "fn_call"
-              },
-              {
-                "bytes": "0000000000000000000000000000000000000000000000000000000000000001"
-              },
-              {
-                "symbol": "get_data"
-              }
-            ],
-            "data": "void"
-          }
-        }
-      },
-      "failed_call": false
-    },
-    {
-      "event": {
-        "ext": "v0",
-        "contract_id": "0000000000000000000000000000000000000000000000000000000000000001",
-        "type_": "diagnostic",
-        "body": {
-          "v0": {
-            "topics": [
-              {
-                "symbol": "fn_return"
-              },
-              {
-                "symbol": "get_data"
-              }
-            ],
-            "data": {
-              "map": [
-                {
-                  "key": {
-                    "symbol": "admin"
-                  },
-                  "val": {
-                    "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                    "u64": 10000
                   }
                 },
                 {

--- a/test_snapshots/test/test_cancel_admin_change_clears_proposal.1.json
+++ b/test_snapshots/test/test_cancel_admin_change_clears_proposal.1.json
@@ -120,6 +120,14 @@
                             },
                             {
                               "key": {
+                                "symbol": "max_fee_ceiling"
+                              },
+                              "val": {
+                                "u64": 10000
+                              }
+                            },
+                            {
+                              "key": {
                                 "symbol": "value"
                               },
                               "val": {
@@ -131,10 +139,30 @@
                       },
                       {
                         "key": {
+                          "symbol": "LASTACT"
+                        },
+                        "val": {
+                          "u64": 0
+                        }
+                      },
+                      {
+                        "key": {
                           "symbol": "TREASURY"
                         },
                         "val": {
                           "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "SchemaVersion"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "u32": 2
                         }
                       }
                     ]
@@ -589,6 +617,14 @@
                   },
                   "val": {
                     "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                  }
+                },
+                {
+                  "key": {
+                    "symbol": "max_fee_ceiling"
+                  },
+                  "val": {
+                    "u64": 10000
                   }
                 },
                 {


### PR DESCRIPTION
Closes #798

## What this adds

`harvest_and_compound` — a single atomic vault entry point that turns a farmer's accrued-but-idle yield into additional *staked* LP:

1. **Claim** pending emissions from the `lp_farming` pool (`reward_token`).
2. **Swap** them through a caller-supplied external DEX router along a `path` ending at the farm's `lp_token`.
3. **Re-stake** every LP token the swap delivered, raising the caller's share balance and therefore their forward emission rate.

All three steps share one transaction, so a failed or under-delivering swap reverts the claim too: rewards are never consumed without LP coming back.

### Why the route is caller-supplied

There is no on-chain AMM in this contract and the best `reward_token → lp_token` venue changes block to block, so each call names its own `router` and `path` — the "auto-router" of the issue title. An off-chain keeper quotes the market and hands in the route it found.

### Router integration contract

```
swap_exact_tokens_for_tokens(amount_in: i128, amount_out_min: i128, path: Vec<Address>, to: Address)
```

The Uniswap-V2 / Soroswap signature. The vault transfers `amount_in` to the router *before* the call (transfer-then-call); the router delivers the output to `to`.

### Trust model

The router is arbitrary caller-supplied code and is treated as hostile:

- **Output is measured, never reported.** `lp_acquired` is the vault's own `balance()` delta across the swap. The test router deliberately reports `i128::MAX`; every assertion on `lp_acquired` proves the vault ignored it.
- **Slippage is enforced locally.** `amount_out_min` goes to the router as `0`; the binding check runs here against the measured delta, so a router cannot satisfy the bound by lying about it.
- **Re-entry is blocked.** The `lib.rs` wrapper holds the contract-wide reentrancy guard across the untrusted call.
- **Authorization is asserted exactly once.** Soroban permits one `require_auth` per address per invocation frame — a second aborts the host — so downstream steps use a new `lp_farming::stake_preauthorized`.

---

## Security fix: phantom rewards in `lp_farming::stake`

Found while testing the compounding path; **not introduced here, and exploitable today through the shipped `stake_lp` entry point.**

`settle_user` wrote `RewardDebt = old_shares × acc / PRECISION`, then `Shares` was increased by `amount` and `RewardDebt` was never recomputed. The new stake therefore carried zero reward debt and was credited on the next settle with `amount × acc_reward_per_share / PRECISION` — the pool's *entire accrued history*, paid out on a stake that had earned nothing. Stake into a mature pool, claim in the same ledger, repeat: the reward pot drains.

Measured before the fix, via `compounding_raises_the_next_harvests_reward`:

| Position | Shares | Ledgers in pool | Earned | Correct |
|---|---|---|---|---|
| Compounded | 1,001,000 | full history | 501 | 500 |
| Flat, staked just now | 1,000,000 | 0 | **1499** | 499 |

The smaller, newer position out-earned the compounded one 3:1 — which also defeats the entire point of #798. Fixed by re-baselining reward debt against the post-stake share count. Three regression tests in `lp_farming` cover it: a fresh staker in a mature pool, share-weighted splitting across two stakers, and topping up an existing stake.

## Bug fix: `vault_deposit` / `vault_withdraw` were unusable

`autocompound::deposit` and `withdraw` each took the reentrancy lock while their `lib.rs` wrappers already held it. The lock is not re-entrant, so both entry points failed with `ReentrancyDetected` on every call. Removed the inner guards; the wrapper keeps its own.

---

## Prerequisite: `main` did not compile

None of the above could be built or tested until these were fixed. Each was forced — there is exactly one way to make the code compile — and none relate to #798.

| File | Problem |
|---|---|
| `src/lib.rs` | `ContractError` declared **59 variants**; `#[contracterror]` caps at **50** (`VecM<ScSpecUdtErrorEnumCaseV0, 50>` in stellar-xdr). The macro panicked with `LengthExceedsMax`, so `ContractError` never existed and 259 errors cascaded from it. Also three variant names and two discriminants were declared twice. |
| `src/escrow/merkle.rs` | `symbol_short!("merkle_add")` — 10 chars, max 9. |
| `src/vaults/autocompound.rs` | `symbol_short!("on_flash_loan")` — 13 chars. |
| `src/bridge/mint.rs` | A bad merge left two topic tuples in each `events().publish()` call, passing 3 arguments to a 2-argument method. |
| `src/vaults/lp_farming.rs` | `RewardDebt(user)` moved `user` before a later use of it. |
| `Cargo.toml` | `soroban-sdk`'s `testutils` feature was enabled in `[dependencies]` **and** in `[workspace.dependencies]`. It needs `std` and `rand`, neither of which builds for `wasm32-unknown-unknown`, so `cargo build --target wasm32-unknown-unknown --release` — a CI step — could not compile at all. |

The `testutils` removal deserves a note: features named in `[workspace.dependencies]` are inherited by every member writing `soroban-sdk.workspace = true`, and a member's own `default-features = false` cannot drop them. That forced `testutils` into the *normal* dependency graph via `ledger-time-helper`, which the root crate depends on. Every member already requests it explicitly in its own `[dev-dependencies]`, so tests are unaffected.

Getting under the 50-variant cap meant removing nine. Eight of them — the `Bridge*` family — **already had byte-identical associated-const aliases** at `lib.rs:187-194`, left over from a half-finished migration; deleting the variants is what that code already intended. `NullifierAlreadyUsed` became an alias to `AlreadyRegistered`. Every `ContractError::X` use site still resolves; the wire error codes for those nine now map to their alias targets.

### Test target

`cargo test` additionally failed to compile. Fixed: enum storage keys constructed as tuple structs (`src/test.rs`), `Budget::cpu_instruction_count`/`memory_allocation` → `cpu_instruction_cost`/`memory_bytes_cost` (`src/kernel/budget.rs`), `Map::try_insert` (`src/events/events.rs`), missing `testutils` trait imports (`src/events/swaps.rs`), `setup()` helpers whose declared tuple arity disagreed with what they returned (`src/vaults/pause_guard.rs`, `src/security/pausable.rs`), twelve `ContractData` initializers missing `max_fee_ceiling`, `ContractError::AdminChangeTimelockNotSatisfied` → `AdminChangeTimelockNotSatis`, and `client.add_corridor_fees` calls against an entry point that was never wired up (`fees::add_corridor_fees` existed but was not exported — now it is).

`get_last_update_timestamp` took a `Symbol` while its siblings `update_heartbeat` and `is_data_fresh` take an `AssetId`, and every caller passed an `AssetId`. Changed to `AssetId`.

Five `pause_guard` tests called two auth-requiring functions inside one `env.as_contract` frame and failed with `Auth, ExistingValue` — the same one-`require_auth`-per-frame rule described above. Split into one frame per call.

---

## Test coverage

16 tests for the new entry point:

- **Happy path** — reward claimed, LP acquired matches the measured delta (not the router's `i128::MAX`), shares rise by exactly the LP acquired, nothing stranded with the caller, event payload correct, and a compounded position out-earns a flat one.
- **Rejections** — nothing accrued, negative `min_lp_out`, path not starting at `reward_token`, not ending at `lp_token`, single-hop, longer than the hop cap, router delivers nothing, router under-delivers against `min_lp_out`, vault paused, reentrancy lock held.
- **Atomicity** — a failed swap leaves the reward claimable and shares unchanged; the same rewards then compound successfully through a working route.

Plus 3 regression tests for the `lp_farming` reward-debt fix.

The reentrancy case asserts against a held lock rather than driving a router that calls back in: on soroban-sdk 20.0.0 a *sub*-invocation returning `Err` escalates to a non-unwinding panic and aborts the whole test process, so a live re-entry cannot be observed. Holding the lock reproduces the exact state a re-entrant call would meet.

## WASM size budget is not met

With the build fixed, `cargo build --target wasm32-unknown-unknown --release` produces **228,987 bytes**. `check_size.sh` caps binaries at **46,080** (45 KB), so that CI step fails by roughly 5x.

This is not something #798 can resolve: the new module is a couple of hundred lines against a mega-contract spanning several dozen subsystems, and the budget has never actually been enforced because the WASM target has never compiled. Bringing a 229 KB contract under 45 KB is a separate exercise — most likely splitting the mega-contract, which is an architectural decision rather than a change to this feature. Flagging it explicitly rather than quietly relaxing the threshold.

## Known pre-existing failures, not addressed here

Unbreaking the build revealed runtime failures in modules unrelated to #798, concentrated in `settlement::htlc`, `staging`, `escrow::timelock` and `bridge::mint`. They are pre-existing and out of scope for this PR; `main` has been red regardless, since CI runs `cargo test`. All of `vaults::` is green.

Running the suite now generates 169 new files under `test_snapshots/` — 124k lines, from tests that previously never ran to completion. They are **deliberately left out of this PR**: they are regenerated deterministically by `cargo test`, nothing in CI reads them, and committing them would bury ~1,000 lines of real change under two orders of magnitude of JSON. The 12 existing snapshots whose contents genuinely change (the contract spec gains `add_corridor_fees` and `get_last_update_timestamp` changes signature) *are* included.

`cargo test --lib` still aborts partway through on a pre-existing non-unwinding panic — the soroban-sdk 20.0.0 behaviour described above, where a sub-invocation returning `Err` aborts the process rather than unwinding — so a complete tally is not available on this tree. Counted up to the abort: 211 pass, 73 fail. The `vaults::` subtree, which contains all of this PR's code, is 43/43.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
