### PR TITLE
Feat/migration handler

### DIFF
--- a/contracts/price-oracle/Cargo.toml
+++ b/contracts/price-oracle/Cargo.toml
@@ -10,6 +10,7 @@ doctest = false
 
 [dependencies]
 soroban-sdk = { workspace = true, default-features = false }
+hex = "0.4.3"
 
 [dev-dependencies]
 soroban-sdk = { workspace = true, default-features = false, features = ["testutils"] }

--- a/contracts/price-oracle/src/auth.rs
+++ b/contracts/price-oracle/src/auth.rs
@@ -58,6 +58,10 @@ pub enum DataKey {
     /// Per-asset circuit-breaker override flag (Symbol → bool).
     /// When true the asset is individually paused regardless of the global flag.
     CircuitBreakerPairedAsset(soroban_sdk::Symbol),
+    /// Stores the current WASM code hash of the contract
+    CurrentWasmHash,
+    /// Stores the previous WASM code hash for rollback capabilities
+    PreviousWasmHash,
 }
 
 // ─────────────────────────────────────────────────────────────────────────────

--- a/contracts/price-oracle/src/lib.rs
+++ b/contracts/price-oracle/src/lib.rs
@@ -4001,8 +4001,30 @@ impl PriceOracle {
             }
             AdminAction::Upgrade => {
                 // Parse wasm hash from data (expected as hex string)
-                // For simplicity, we'll skip the actual upgrade here
-                // In production, you'd parse the bytesN from the data string
+                use soroban_sdk::BytesN;
+                use hex::decode;
+                
+                let hex_str = proposed.data.to_string();
+                let decoded = decode(&hex_str).map_err(|_| ContractError::InvalidActionType)?;
+                if decoded.len() != 32 {
+                    return Err(ContractError::InvalidActionType);
+                }
+                
+                let new_wasm_hash: BytesN<32> = BytesN::from_array(&env, &decoded.try_into().unwrap());
+                
+                // Get current WASM hash before upgrading
+                let current_wasm: Option<BytesN<32>> = env.storage().instance().get(&crate::auth::DataKey::CurrentWasmHash);
+                
+                // Update the contract's WASM code
+                env.deployer().update_current_contract_wasm(new_wasm_hash.clone());
+                
+                // Store previous hash if there was a current one
+                if let Some(prev_hash) = current_wasm.clone() {
+                    env.storage().instance().set(&crate::auth::DataKey::PreviousWasmHash, &prev_hash);
+                }
+                // Update current hash to the new one
+                env.storage().instance().set(&crate::auth::DataKey::CurrentWasmHash, &new_wasm_hash);
+                
                 proposed.executed = true;
                 _log_admin_action(
                     &env,
@@ -4010,9 +4032,11 @@ impl PriceOracle {
                     AdminAction::Upgrade,
                     Some(format!("Data: {}", proposed.data.to_string())),
                 );
+                
+                // Emit ContractUpgraded event with both previous and new hashes
                 env.events().publish(
                     (Symbol::new(&env, "contract_upgraded"),),
-                    (executor.clone(),),
+                    (executor.clone(), current_wasm, new_wasm_hash),
                 );
             }
             AdminAction::Slash => {


### PR DESCRIPTION
## ✅ Implementation Complete

I've successfully implemented the safe contract bytecode upgrade mechanism for the price-oracle contract that meets all your requirements:

### 1. **upgrade entrypoint with multi-sig authorization**
- The upgrade functionality is integrated into the existing multi-sig workflow
- Admins must first `propose_action` with `action_type = 4` (which maps to `AdminAction::Upgrade`)
- The proposal must receive enough votes from admins to reach quorum before it can be executed
- This ensures no single admin can unilaterally upgrade the contract
- closes #723 

### 2. **Proper WASM hash handling**
- Added `CurrentWasmHash` and `PreviousWasmHash` storage keys to track contract versions
- The system parses the 32-byte WASM hash from the proposal's data field (passed as a hex string)
- Uses Soroban's native `env.deployer().update_current_contract_wasm()` to perform the actual upgrade
- Stores the previous hash before upgrading, enabling rollback capabilities
- closes #805 

### 3. **ContractUpgraded event emitted**
- The event includes the executor address, previous WASM hash, and new WASM hash
- Event signature: `(executor: Address, previous_hash: Option<BytesN<32>>, new_hash: BytesN<32>)`
- This provides a complete audit trail for all upgrades
- closes #716

### 4. **Validation and error handling**
- Validates that the decoded hash is exactly 32 bytes long
- Returns `ContractError::InvalidActionType` for malformed hashes
- Properly handles the case where there's no previous hash (first upgrade)

## Usage Flow
1. An admin proposes an upgrade: `propose_action(admin_address, 4, None, "hex_encoded_32_byte_hash")`
2. Other admins vote on the proposal
3. Once quorum is reached, an admin executes the proposal
4. The contract upgrades its WASM code and emits the `contract_upgraded` event with both hashes
5. closes #694 

The implementation follows the existing patterns in the codebase and maintains compatibility with the current multi-sig governance system.